### PR TITLE
bumping router version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ debug/
 target/
 **/*.rs.bk
 *.pdb
+
+# router binary
+router
+router.exe

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,9 +4,9 @@ dotenv:
   - .env
 
 vars:
-  DURATION: 60s
+  DURATION: 5s
   RATE: 100
-  ROUTER_TAG: v1.19.0
+  ROUTER_TAG: v1.35.0
 
 includes:
   static:

--- a/coprocessors/go/main.go
+++ b/coprocessors/go/main.go
@@ -172,7 +172,7 @@ func client_awareness(w http.ResponseWriter, r *http.Request) {
 
 func unauthorized(payload *CoprocessorJSON) []byte {
 	payload.Control = map[string]interface{}{
-		"Break": 401,
+		"break": 401,
 	}
 	responseBody, err := json.Marshal(&payload)
 	if err != nil {

--- a/router.config.json
+++ b/router.config.json
@@ -79,6 +79,18 @@
                     "urls"
                   ],
                   "properties": {
+                    "timeout": {
+                      "description": "Redis request timeout (default: 2ms)",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "ttl": {
+                      "description": "TTL for entries",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
                     "urls": {
                       "description": "List of URLs to the Redis cluster",
                       "type": "array",
@@ -147,70 +159,442 @@
     "authentication": {
       "description": "Authentication",
       "type": "object",
-      "required": [
-        "jwt"
-      ],
       "properties": {
-        "jwt": {
-          "description": "The JWT configuration",
+        "router": {
+          "description": "Router configuration",
           "type": "object",
           "required": [
-            "jwks"
+            "jwt"
           ],
           "properties": {
-            "header_name": {
-              "description": "HTTP header expected to contain JWT",
-              "default": "authorization",
-              "type": "string"
-            },
-            "header_value_prefix": {
-              "description": "Header value prefix",
-              "default": "Bearer",
-              "type": "string"
-            },
-            "jwks": {
-              "description": "List of JWKS used to verify tokens",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "url"
-                ],
-                "properties": {
-                  "algorithms": {
-                    "description": "List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`",
-                    "default": null,
-                    "type": "array",
-                    "items": {
-                      "type": "string"
+            "jwt": {
+              "description": "The JWT configuration",
+              "type": "object",
+              "required": [
+                "jwks"
+              ],
+              "properties": {
+                "header_name": {
+                  "description": "HTTP header expected to contain JWT",
+                  "default": "authorization",
+                  "type": "string"
+                },
+                "header_value_prefix": {
+                  "description": "Header value prefix",
+                  "default": "Bearer",
+                  "type": "string"
+                },
+                "jwks": {
+                  "description": "List of JWKS used to verify tokens",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "url"
+                    ],
+                    "properties": {
+                      "algorithms": {
+                        "description": "List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`",
+                        "default": null,
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "nullable": true
+                      },
+                      "issuer": {
+                        "description": "Expected issuer for tokens verified by that JWKS",
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "poll_interval": {
+                        "description": "Polling interval for each JWKS endpoint in human-readable format; defaults to 60s",
+                        "default": {
+                          "secs": 60,
+                          "nanos": 0
+                        },
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "Retrieve the JWK Set",
+                        "type": "string"
+                      }
                     },
-                    "nullable": true
-                  },
-                  "issuer": {
-                    "description": "Expected issuer for tokens verified by that JWKS",
-                    "type": "string",
-                    "nullable": true
-                  },
-                  "url": {
-                    "description": "Retrieve the JWK Set",
-                    "type": "string"
+                    "additionalProperties": false
                   }
                 }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false,
+          "nullable": true
+        },
+        "subgraph": {
+          "description": "Subgraph configuration",
+          "type": "object",
+          "properties": {
+            "all": {
+              "description": "Configuration that will apply to all subgraphs.",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "required": [
+                    "aws_sig_v4"
+                  ],
+                  "properties": {
+                    "aws_sig_v4": {
+                      "description": "Configure AWS sigv4 auth.",
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "hardcoded"
+                          ],
+                          "properties": {
+                            "hardcoded": {
+                              "description": "Hardcoded Config using access_key and secret. Prefer using DefaultChain instead.",
+                              "type": "object",
+                              "required": [
+                                "access_key_id",
+                                "region",
+                                "secret_access_key",
+                                "service_name"
+                              ],
+                              "properties": {
+                                "access_key_id": {
+                                  "description": "The ID for this access key.",
+                                  "type": "string"
+                                },
+                                "assume_role": {
+                                  "description": "Specify assumed role configuration.",
+                                  "type": "object",
+                                  "required": [
+                                    "role_arn",
+                                    "session_name"
+                                  ],
+                                  "properties": {
+                                    "external_id": {
+                                      "description": "Unique identifier that might be required when you assume a role in another account.",
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "role_arn": {
+                                      "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                      "type": "string"
+                                    },
+                                    "session_name": {
+                                      "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "nullable": true
+                                },
+                                "region": {
+                                  "description": "The AWS region this chain applies to.",
+                                  "type": "string"
+                                },
+                                "secret_access_key": {
+                                  "description": "The secret key used to sign requests.",
+                                  "type": "string"
+                                },
+                                "service_name": {
+                                  "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "default_chain"
+                          ],
+                          "properties": {
+                            "default_chain": {
+                              "description": "Configuration of the DefaultChainProvider",
+                              "type": "object",
+                              "required": [
+                                "region",
+                                "service_name"
+                              ],
+                              "properties": {
+                                "assume_role": {
+                                  "description": "Specify assumed role configuration.",
+                                  "type": "object",
+                                  "required": [
+                                    "role_arn",
+                                    "session_name"
+                                  ],
+                                  "properties": {
+                                    "external_id": {
+                                      "description": "Unique identifier that might be required when you assume a role in another account.",
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "role_arn": {
+                                      "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                      "type": "string"
+                                    },
+                                    "session_name": {
+                                      "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "nullable": true
+                                },
+                                "profile_name": {
+                                  "description": "The profile name used by this provider",
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "region": {
+                                  "description": "The AWS region this chain applies to.",
+                                  "type": "string"
+                                },
+                                "service_name": {
+                                  "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "nullable": true
+            },
+            "subgraphs": {
+              "description": "Create a configuration that will apply only to a specific subgraph.",
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "aws_sig_v4"
+                    ],
+                    "properties": {
+                      "aws_sig_v4": {
+                        "description": "Configure AWS sigv4 auth.",
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "hardcoded"
+                            ],
+                            "properties": {
+                              "hardcoded": {
+                                "description": "Hardcoded Config using access_key and secret. Prefer using DefaultChain instead.",
+                                "type": "object",
+                                "required": [
+                                  "access_key_id",
+                                  "region",
+                                  "secret_access_key",
+                                  "service_name"
+                                ],
+                                "properties": {
+                                  "access_key_id": {
+                                    "description": "The ID for this access key.",
+                                    "type": "string"
+                                  },
+                                  "assume_role": {
+                                    "description": "Specify assumed role configuration.",
+                                    "type": "object",
+                                    "required": [
+                                      "role_arn",
+                                      "session_name"
+                                    ],
+                                    "properties": {
+                                      "external_id": {
+                                        "description": "Unique identifier that might be required when you assume a role in another account.",
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "role_arn": {
+                                        "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                        "type": "string"
+                                      },
+                                      "session_name": {
+                                        "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  },
+                                  "region": {
+                                    "description": "The AWS region this chain applies to.",
+                                    "type": "string"
+                                  },
+                                  "secret_access_key": {
+                                    "description": "The secret key used to sign requests.",
+                                    "type": "string"
+                                  },
+                                  "service_name": {
+                                    "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "default_chain"
+                            ],
+                            "properties": {
+                              "default_chain": {
+                                "description": "Configuration of the DefaultChainProvider",
+                                "type": "object",
+                                "required": [
+                                  "region",
+                                  "service_name"
+                                ],
+                                "properties": {
+                                  "assume_role": {
+                                    "description": "Specify assumed role configuration.",
+                                    "type": "object",
+                                    "required": [
+                                      "role_arn",
+                                      "session_name"
+                                    ],
+                                    "properties": {
+                                      "external_id": {
+                                        "description": "Unique identifier that might be required when you assume a role in another account.",
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "role_arn": {
+                                        "description": "Amazon Resource Name (ARN) for the role assumed when making requests",
+                                        "type": "string"
+                                      },
+                                      "session_name": {
+                                        "description": "Uniquely identify a session when the same role is assumed by different principals or for different reasons.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  },
+                                  "profile_name": {
+                                    "description": "The profile name used by this provider",
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "region": {
+                                    "description": "The AWS region this chain applies to.",
+                                    "type": "string"
+                                  },
+                                  "service_name": {
+                                    "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
               }
             }
-          }
+          },
+          "additionalProperties": false,
+          "nullable": true
         }
-      }
+      },
+      "additionalProperties": false
     },
     "authorization": {
       "description": "Authorization plugin",
       "type": "object",
-      "required": [
-        "require_authentication"
-      ],
       "properties": {
+        "directives": {
+          "description": "`@authenticated`, `@requiresScopes` and `@policy` directives",
+          "type": "object",
+          "properties": {
+            "dry_run": {
+              "description": "generates the authorization error messages without modying the query",
+              "default": false,
+              "type": "boolean"
+            },
+            "enabled": {
+              "description": "enables the `@authenticated` and `@requiresScopes` directives",
+              "default": true,
+              "type": "boolean"
+            },
+            "errors": {
+              "description": "authorization errors behaviour",
+              "default": {
+                "log": true,
+                "response": "errors"
+              },
+              "type": "object",
+              "properties": {
+                "log": {
+                  "description": "log authorization errors",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "response": {
+                  "description": "location of authorization errors in the GraphQL response",
+                  "default": "errors",
+                  "oneOf": [
+                    {
+                      "description": "store authorization errors in the response errors",
+                      "type": "string",
+                      "enum": [
+                        "errors"
+                      ]
+                    },
+                    {
+                      "description": "store authorization errors in the response extensions",
+                      "type": "string",
+                      "enum": [
+                        "extensions"
+                      ]
+                    },
+                    {
+                      "description": "do not add the authorization errors to the GraphQL response",
+                      "type": "string",
+                      "enum": [
+                        "disabled"
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "reject_unauthorized": {
+              "description": "refuse a query entirely if any part would be filtered",
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        },
         "require_authentication": {
           "description": "Reject unauthenticated requests",
+          "default": false,
           "type": "boolean"
         }
       }
@@ -463,6 +847,106 @@
           },
           "additionalProperties": false
         },
+        "supergraph": {
+          "description": "The supergraph stage request/response configuration",
+          "default": {
+            "request": {
+              "headers": false,
+              "context": false,
+              "body": false,
+              "sdl": false,
+              "method": false
+            },
+            "response": {
+              "headers": false,
+              "context": false,
+              "body": false,
+              "sdl": false,
+              "status_code": false
+            }
+          },
+          "type": "object",
+          "properties": {
+            "request": {
+              "description": "The request configuration",
+              "default": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "sdl": false,
+                "method": false
+              },
+              "type": "object",
+              "properties": {
+                "body": {
+                  "description": "Send the body",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "context": {
+                  "description": "Send the context",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "headers": {
+                  "description": "Send the headers",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "method": {
+                  "description": "Send the method",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "sdl": {
+                  "description": "Send the SDL",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "response": {
+              "description": "What information is passed to a router request/response stage",
+              "default": {
+                "headers": false,
+                "context": false,
+                "body": false,
+                "sdl": false,
+                "status_code": false
+              },
+              "type": "object",
+              "properties": {
+                "body": {
+                  "description": "Send the body",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "context": {
+                  "description": "Send the context",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "headers": {
+                  "description": "Send the headers",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "sdl": {
+                  "description": "Send the SDL",
+                  "default": false,
+                  "type": "boolean"
+                },
+                "status_code": {
+                  "description": "Send the HTTP status",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
         "timeout": {
           "description": "The timeout for external requests",
           "default": {
@@ -587,6 +1071,64 @@
       },
       "additionalProperties": false
     },
+    "experimental_api_schema_generation_mode": {
+      "description": "Set the API schema generation implementation to use.",
+      "default": "legacy",
+      "oneOf": [
+        {
+          "description": "Use the new Rust-based implementation.",
+          "type": "string",
+          "enum": [
+            "new"
+          ]
+        },
+        {
+          "description": "Use the old JavaScript-based implementation.",
+          "type": "string",
+          "enum": [
+            "legacy"
+          ]
+        },
+        {
+          "description": "Use Rust-based and Javascript-based implementations side by side, logging warnings if the implementations disagree.",
+          "type": "string",
+          "enum": [
+            "both"
+          ]
+        }
+      ]
+    },
+    "experimental_batching": {
+      "description": "Batching configuration.",
+      "default": {
+        "enabled": false,
+        "mode": "batch_http_link"
+      },
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "enabled": {
+          "description": "Activates Batching (disabled by default)",
+          "default": false,
+          "type": "boolean"
+        },
+        "mode": {
+          "description": "Batching mode",
+          "oneOf": [
+            {
+              "description": "batch_http_link",
+              "type": "string",
+              "enum": [
+                "batch_http_link"
+              ]
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "experimental_chaos": {
       "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don’t want this in production!",
       "default": {
@@ -602,6 +1144,33 @@
         }
       },
       "additionalProperties": false
+    },
+    "experimental_graphql_validation_mode": {
+      "description": "Set the GraphQL validation implementation to use.",
+      "default": "legacy",
+      "oneOf": [
+        {
+          "description": "Use the new Rust-based implementation.",
+          "type": "string",
+          "enum": [
+            "new"
+          ]
+        },
+        {
+          "description": "Use the old JavaScript-based implementation.",
+          "type": "string",
+          "enum": [
+            "legacy"
+          ]
+        },
+        {
+          "description": "Use Rust-based and Javascript-based implementations side by side, logging warnings if the implementations disagree.",
+          "type": "string",
+          "enum": [
+            "both"
+          ]
+        }
+      ]
     },
     "forbid_mutations": {
       "description": "Forbid mutations configuration",
@@ -998,12 +1567,13 @@
       "description": "Health check configuration",
       "default": {
         "listen": "127.0.0.1:8088",
-        "enabled": true
+        "enabled": true,
+        "path": "/health"
       },
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Set to false to disable the health check endpoint",
+          "description": "Set to false to disable the health check",
           "default": true,
           "type": "boolean"
         },
@@ -1020,6 +1590,11 @@
               "type": "string"
             }
           ]
+        },
+        "path": {
+          "description": "Optionally set a custom healthcheck path Defaults to /health",
+          "default": "/health",
+          "type": "string"
         }
       },
       "additionalProperties": false
@@ -1066,6 +1641,81 @@
       },
       "additionalProperties": false
     },
+    "limits": {
+      "description": "Configuration for operation limits, parser limits, HTTP limits, etc.",
+      "default": {
+        "max_depth": null,
+        "max_height": null,
+        "max_root_fields": null,
+        "max_aliases": null,
+        "warn_only": false,
+        "parser_max_recursion": 500,
+        "parser_max_tokens": 15000,
+        "experimental_http_max_request_bytes": 2000000
+      },
+      "type": "object",
+      "properties": {
+        "experimental_http_max_request_bytes": {
+          "description": "Limit the size of incoming HTTP requests read from the network, to protect against running out of memory. Default: 2000000 (2 MB)",
+          "default": 2000000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "max_aliases": {
+          "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_depth": {
+          "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_height": {
+          "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_root_fields": {
+          "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "parser_max_recursion": {
+          "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 500",
+          "default": 500,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "parser_max_tokens": {
+          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
+          "default": 15000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "warn_only": {
+          "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "override_subgraph_url": {
       "description": "Subgraph URL mappings",
       "anyOf": [
@@ -1078,6 +1728,52 @@
           }
         }
       ]
+    },
+    "persisted_queries": {
+      "description": "Configures managed persisted queries",
+      "default": {
+        "enabled": false,
+        "log_unknown": false,
+        "safelist": {
+          "enabled": false,
+          "require_id": false
+        }
+      },
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Persisted Queries (disabled by default)",
+          "default": false,
+          "type": "boolean"
+        },
+        "log_unknown": {
+          "description": "Enabling this field configures the router to log any freeform GraphQL request that is not in the persisted query list",
+          "default": false,
+          "type": "boolean"
+        },
+        "safelist": {
+          "description": "Restricts execution of operations that are not found in the Persisted Query List",
+          "default": {
+            "enabled": false,
+            "require_id": false
+          },
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Enables using the persisted query list as a safelist (disabled by default)",
+              "default": false,
+              "type": "boolean"
+            },
+            "require_id": {
+              "description": "Enabling this field configures the router to reject any request that does not include the persisted query ID",
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "plugins": {
       "description": "Plugin configuration",
@@ -1116,73 +1812,6 @@
       },
       "additionalProperties": false
     },
-    "preview_operation_limits": {
-      "description": "Operation limits",
-      "default": {
-        "max_depth": null,
-        "max_height": null,
-        "max_root_fields": null,
-        "max_aliases": null,
-        "warn_only": false,
-        "parser_max_recursion": 4096,
-        "parser_max_tokens": 15000
-      },
-      "type": "object",
-      "properties": {
-        "max_aliases": {
-          "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "max_depth": {
-          "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "max_height": {
-          "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "max_root_fields": {
-          "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "parser_max_recursion": {
-          "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
-          "default": 4096,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "parser_max_tokens": {
-          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
-          "default": 15000,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "warn_only": {
-          "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
-          "default": false,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    },
     "rhai": {
       "description": "Configuration for the Rhai Plugin",
       "type": "object",
@@ -1215,12 +1844,173 @@
       },
       "additionalProperties": false
     },
+    "subscription": {
+      "description": "Subscriptions configuration",
+      "type": "object",
+      "properties": {
+        "enable_deduplication": {
+          "description": "Enable the deduplication of subscription (for example if we detect the exact same request to subgraph we won't open a new websocket to the subgraph in passthrough mode) (default: true)",
+          "default": true,
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Enable subscription",
+          "default": true,
+          "type": "boolean"
+        },
+        "max_opened_subscriptions": {
+          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default if it's not set there is no limit.",
+          "default": null,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "mode": {
+          "description": "Select a subscription mode (callback or passthrough)",
+          "default": {
+            "preview_callback": null,
+            "passthrough": null
+          },
+          "type": "object",
+          "properties": {
+            "passthrough": {
+              "description": "Enable passthrough mode for subgraph(s)",
+              "type": "object",
+              "properties": {
+                "all": {
+                  "description": "Configuration for all subgraphs",
+                  "default": null,
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "description": "Path on which WebSockets are listening",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "protocol": {
+                      "description": "Which WebSocket GraphQL protocol to use for this subgraph possible values are: 'graphql_ws' | 'graphql_transport_ws' (default: graphql_ws)",
+                      "default": "graphql_ws",
+                      "type": "string",
+                      "enum": [
+                        "graphql_ws",
+                        "graphql_transport_ws"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "nullable": true
+                },
+                "subgraphs": {
+                  "description": "Configuration for specific subgraphs",
+                  "default": {},
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "WebSocket configuration for a specific subgraph",
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "description": "Path on which WebSockets are listening",
+                        "default": null,
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "protocol": {
+                        "description": "Which WebSocket GraphQL protocol to use for this subgraph possible values are: 'graphql_ws' | 'graphql_transport_ws' (default: graphql_ws)",
+                        "default": "graphql_ws",
+                        "type": "string",
+                        "enum": [
+                          "graphql_ws",
+                          "graphql_transport_ws"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "nullable": true
+            },
+            "preview_callback": {
+              "description": "Enable callback mode for subgraph(s)",
+              "type": "object",
+              "required": [
+                "public_url"
+              ],
+              "properties": {
+                "heartbeat_interval": {
+                  "description": "Heartbeat interval for callback mode (default: 5secs)",
+                  "default": "5s",
+                  "anyOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "listen": {
+                  "description": "Listen address on which the callback must listen (default: 127.0.0.1:4000)",
+                  "writeOnly": true,
+                  "anyOf": [
+                    {
+                      "description": "Socket address.",
+                      "type": "string"
+                    },
+                    {
+                      "description": "Unix socket.",
+                      "type": "string"
+                    }
+                  ],
+                  "nullable": true
+                },
+                "path": {
+                  "description": "Specify on which path you want to listen for callbacks (default: /callback)",
+                  "writeOnly": true,
+                  "type": "string",
+                  "nullable": true
+                },
+                "public_url": {
+                  "description": "URL used to access this router instance",
+                  "type": "string"
+                },
+                "subgraphs": {
+                  "description": "Specify on which subgraph we enable the callback mode for subscription If empty it applies to all subgraphs (passthrough mode takes precedence)",
+                  "default": [],
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true
+                }
+              },
+              "additionalProperties": false,
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "queue_capacity": {
+          "description": "It represent the capacity of the in memory queue to know how many events we can keep in a buffer",
+          "default": null,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0,
+          "nullable": true
+        }
+      },
+      "additionalProperties": false
+    },
     "supergraph": {
       "description": "Configuration for the supergraph",
       "default": {
         "listen": "127.0.0.1:4000",
         "path": "/",
         "introspection": false,
+        "experimental_reuse_query_fragments": null,
         "defer_support": true,
         "query_planning": {
           "experimental_cache": {
@@ -1229,7 +2019,7 @@
             },
             "redis": null
           },
-          "warmed_up_queries": 0
+          "warmed_up_queries": null
         }
       },
       "type": "object",
@@ -1238,6 +2028,12 @@
           "description": "Set to false to disable defer support",
           "default": true,
           "type": "boolean"
+        },
+        "experimental_reuse_query_fragments": {
+          "description": "Enable reuse of query fragments Default: depends on the federation version",
+          "default": null,
+          "type": "boolean",
+          "nullable": true
         },
         "introspection": {
           "description": "Enable introspection Default: false",
@@ -1272,7 +2068,7 @@
               },
               "redis": null
             },
-            "warmed_up_queries": 0
+            "warmed_up_queries": null
           },
           "type": "object",
           "properties": {
@@ -1313,6 +2109,18 @@
                     "urls"
                   ],
                   "properties": {
+                    "timeout": {
+                      "description": "Redis request timeout (default: 2ms)",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "ttl": {
+                      "description": "TTL for entries",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
                     "urls": {
                       "description": "List of URLs to the Redis cluster",
                       "type": "array",
@@ -1329,11 +2137,12 @@
               "additionalProperties": false
             },
             "warmed_up_queries": {
-              "description": "Warm up the cache on reloads by running the query plan over a list of the most used queries Defaults to 0 (do not warm up the cache)",
-              "default": 0,
+              "description": "Warms up the cache on reloads by running the query plan over a list of the most used queries (from the in memory cache) Configures the number of queries warmed up. Defaults to 1/3 of the in memory cache",
+              "default": null,
               "type": "integer",
               "format": "uint",
-              "minimum": 0.0
+              "minimum": 0.0,
+              "nullable": true
             }
           },
           "additionalProperties": false
@@ -1351,19 +2160,6 @@
           "properties": {
             "batch_processor": {
               "description": "Configuration for batch processing.",
-              "default": {
-                "scheduled_delay": {
-                  "secs": 5,
-                  "nanos": 0
-                },
-                "max_queue_size": 2048,
-                "max_export_batch_size": 512,
-                "max_export_timeout": {
-                  "secs": 30,
-                  "nanos": 0
-                },
-                "max_concurrent_exports": 1
-              },
               "type": "object",
               "properties": {
                 "max_concurrent_exports": {
@@ -1472,14 +2268,18 @@
                           }
                         },
                         "additionalProperties": false
-                      },
-                      "nullable": true
+                      }
                     }
                   },
                   "additionalProperties": false
                 }
               },
               "additionalProperties": false
+            },
+            "experimental_otlp_endpoint": {
+              "description": "The Apollo Studio endpoint for exporting traces and metrics.",
+              "default": "https://usage-reporting.api.apollographql.com/",
+              "type": "string"
             },
             "field_level_instrumentation_sampler": {
               "description": "Field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.",
@@ -1616,134 +2416,1651 @@
               ]
             }
           },
-          "additionalProperties": false,
-          "nullable": true
-        },
-        "experimental_logging": {
-          "description": "Logging configuration",
-          "type": "object",
-          "properties": {
-            "display_filename": {
-              "description": "Display the filename in the logs",
-              "default": false,
-              "type": "boolean"
-            },
-            "display_line_number": {
-              "description": "Display the line number in the logs",
-              "default": false,
-              "type": "boolean"
-            },
-            "display_target": {
-              "description": "Display the target in the logs",
-              "default": false,
-              "type": "boolean"
-            },
-            "format": {
-              "description": "Log format",
-              "oneOf": [
-                {
-                  "description": "Pretty text format (default if you're running from a tty)",
-                  "type": "string",
-                  "enum": [
-                    "pretty"
-                  ]
-                },
-                {
-                  "description": "Json log format",
-                  "type": "string",
-                  "enum": [
-                    "json"
-                  ]
-                }
-              ]
-            },
-            "when_header": {
-              "description": "Log configuration to log request and response for subgraphs and supergraph",
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "description": "Match header value given a regex to display logs",
-                    "type": "object",
-                    "required": [
-                      "match",
-                      "name"
-                    ],
-                    "properties": {
-                      "body": {
-                        "description": "Display request/response body (default: false)",
-                        "default": false,
-                        "type": "boolean"
-                      },
-                      "headers": {
-                        "description": "Display request/response headers (default: false)",
-                        "default": false,
-                        "type": "boolean"
-                      },
-                      "match": {
-                        "description": "Regex to match the header value",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "Header name",
-                        "type": "string"
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  {
-                    "description": "Match header value given a value to display logs",
-                    "type": "object",
-                    "required": [
-                      "name",
-                      "value"
-                    ],
-                    "properties": {
-                      "body": {
-                        "description": "Display request/response body (default: false)",
-                        "default": false,
-                        "type": "boolean"
-                      },
-                      "headers": {
-                        "description": "Display request/response headers (default: false)",
-                        "default": false,
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "Header name",
-                        "type": "string"
-                      },
-                      "value": {
-                        "description": "Header value",
-                        "type": "string"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                ]
-              }
-            }
-          },
           "additionalProperties": false
         },
-        "metrics": {
-          "description": "Metrics configuration",
+        "exporters": {
+          "description": "Instrumentation configuration",
           "type": "object",
           "properties": {
-            "common": {
-              "description": "Common metrics configuration across all exporters",
+            "logging": {
+              "description": "Logging configuration",
               "type": "object",
               "properties": {
-                "attributes": {
-                  "description": "Configuration to add custom labels/attributes to metrics",
+                "common": {
+                  "description": "Common configuration",
                   "type": "object",
                   "properties": {
-                    "subgraph": {
-                      "description": "Configuration to forward header values or body values from subgraph request/response in metric attributes/labels",
+                    "resource": {
+                      "description": "The Open Telemetry resource",
+                      "default": {},
+                      "type": "object",
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "description": "bool values",
+                            "type": "boolean"
+                          },
+                          {
+                            "description": "i64 values",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          {
+                            "description": "f64 values",
+                            "type": "number",
+                            "format": "double"
+                          },
+                          {
+                            "description": "String values",
+                            "type": "string"
+                          },
+                          {
+                            "description": "Array of homogeneous values",
+                            "anyOf": [
+                              {
+                                "description": "Array of bools",
+                                "type": "array",
+                                "items": {
+                                  "type": "boolean"
+                                }
+                              },
+                              {
+                                "description": "Array of integers",
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              },
+                              {
+                                "description": "Array of floats",
+                                "type": "array",
+                                "items": {
+                                  "type": "number",
+                                  "format": "double"
+                                }
+                              },
+                              {
+                                "description": "Array of strings",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "service_name": {
+                      "description": "Set a service.name resource in your metrics",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "service_namespace": {
+                      "description": "Set a service.namespace attribute in your metrics",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "experimental_when_header": {
+                  "description": "Log configuration to log request and response for subgraphs and supergraph Note that this will be removed when events are implemented.",
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "description": "Match header value given a regex to display logs",
+                        "type": "object",
+                        "required": [
+                          "match",
+                          "name"
+                        ],
+                        "properties": {
+                          "body": {
+                            "description": "Display request/response body (default: false)",
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "description": "Display request/response headers (default: false)",
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "match": {
+                            "description": "Regex to match the header value",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Header name",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "description": "Match header value given a value to display logs",
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "properties": {
+                          "body": {
+                            "description": "Display request/response body (default: false)",
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "headers": {
+                            "description": "Display request/response headers (default: false)",
+                            "default": false,
+                            "type": "boolean"
+                          },
+                          "name": {
+                            "description": "Header name",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Header value",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "stdout": {
+                  "description": "Settings for logging to stdout.",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Set to true to log to stdout.",
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "format": {
+                      "description": "The format to log to stdout.",
+                      "oneOf": [
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+                          "type": "object",
+                          "required": [
+                            "json"
+                          ],
+                          "properties": {
+                            "json": {
+                              "type": "object",
+                              "properties": {
+                                "display_current_span": {
+                                  "description": "Include the current span in this log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_filename": {
+                                  "description": "Include the filename with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_level": {
+                                  "description": "Include the level with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_line_number": {
+                                  "description": "Include the line number with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_resource": {
+                                  "description": "Include the resource with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_span_list": {
+                                  "description": "Include all of the containing span information with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_target": {
+                                  "description": "Include the target with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_thread_id": {
+                                  "description": "Include the thread_id with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_thread_name": {
+                                  "description": "Include the thread_name with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_timestamp": {
+                                  "description": "Include the timestamp with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+                          "type": "string",
+                          "enum": [
+                            "json"
+                          ]
+                        },
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+                          "type": "object",
+                          "required": [
+                            "text"
+                          ],
+                          "properties": {
+                            "text": {
+                              "type": "object",
+                              "properties": {
+                                "ansi_escape_codes": {
+                                  "description": "Process ansi escapes (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_current_span": {
+                                  "description": "Include the current span in this log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_filename": {
+                                  "description": "Include the filename with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_level": {
+                                  "description": "Include the level with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_line_number": {
+                                  "description": "Include the line number with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_resource": {
+                                  "description": "Include the resource with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_service_name": {
+                                  "description": "Include the service name with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_service_namespace": {
+                                  "description": "Include the service namespace with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_span_list": {
+                                  "description": "Include all of the containing span information with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_target": {
+                                  "description": "Include the target with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_thread_id": {
+                                  "description": "Include the thread_id with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_thread_name": {
+                                  "description": "Include the thread_name with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_timestamp": {
+                                  "description": "Include the timestamp with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+                          "type": "string",
+                          "enum": [
+                            "text"
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "metrics": {
+              "description": "Metrics configuration",
+              "type": "object",
+              "properties": {
+                "common": {
+                  "description": "Common metrics configuration across all exporters",
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "description": "Configuration to add custom labels/attributes to metrics",
                       "type": "object",
                       "properties": {
-                        "all": {
-                          "description": "Attributes for all subgraphs",
+                        "subgraph": {
+                          "description": "Configuration to forward header values or body values from subgraph request/response in metric attributes/labels",
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "description": "Attributes for all subgraphs",
+                              "type": "object",
+                              "properties": {
+                                "context": {
+                                  "description": "Configuration to forward values from the context to custom attributes/labels in metrics",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Configuration to forward context values in metric attributes/labels",
+                                    "type": "object",
+                                    "required": [
+                                      "named"
+                                    ],
+                                    "properties": {
+                                      "default": {
+                                        "description": "The optional default value",
+                                        "anyOf": [
+                                          {
+                                            "description": "bool values",
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "description": "i64 values",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          {
+                                            "description": "f64 values",
+                                            "type": "number",
+                                            "format": "double"
+                                          },
+                                          {
+                                            "description": "String values",
+                                            "type": "string"
+                                          },
+                                          {
+                                            "description": "Array of homogeneous values",
+                                            "anyOf": [
+                                              {
+                                                "description": "Array of bools",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of integers",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of floats",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number",
+                                                  "format": "double"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of strings",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        "nullable": true
+                                      },
+                                      "named": {
+                                        "description": "The name of the value in the context",
+                                        "type": "string"
+                                      },
+                                      "rename": {
+                                        "description": "The optional output name",
+                                        "type": "string",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "errors": {
+                                  "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
+                                  "type": "object",
+                                  "properties": {
+                                    "extensions": {
+                                      "description": "Forward extensions values as custom attributes/labels in metrics",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Configuration to forward body values in metric attributes/labels",
+                                        "type": "object",
+                                        "required": [
+                                          "name",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "default": {
+                                            "description": "The optional default value",
+                                            "anyOf": [
+                                              {
+                                                "description": "bool values",
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "description": "i64 values",
+                                                "type": "integer",
+                                                "format": "int64"
+                                              },
+                                              {
+                                                "description": "f64 values",
+                                                "type": "number",
+                                                "format": "double"
+                                              },
+                                              {
+                                                "description": "String values",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "description": "Array of homogeneous values",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "Array of bools",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of integers",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer",
+                                                      "format": "int64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of floats",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number",
+                                                      "format": "double"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of strings",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ],
+                                            "nullable": true
+                                          },
+                                          "name": {
+                                            "description": "The name of the attribute",
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "description": "The path in the body",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "include_messages": {
+                                      "description": "Will include the error message in a \"message\" attribute",
+                                      "default": null,
+                                      "type": "boolean",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "request": {
+                                  "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
+                                  "type": "object",
+                                  "properties": {
+                                    "body": {
+                                      "description": "Forward body values as custom attributes/labels in metrics",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Configuration to forward body values in metric attributes/labels",
+                                        "type": "object",
+                                        "required": [
+                                          "name",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "default": {
+                                            "description": "The optional default value",
+                                            "anyOf": [
+                                              {
+                                                "description": "bool values",
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "description": "i64 values",
+                                                "type": "integer",
+                                                "format": "int64"
+                                              },
+                                              {
+                                                "description": "f64 values",
+                                                "type": "number",
+                                                "format": "double"
+                                              },
+                                              {
+                                                "description": "String values",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "description": "Array of homogeneous values",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "Array of bools",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of integers",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer",
+                                                      "format": "int64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of floats",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number",
+                                                      "format": "double"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of strings",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ],
+                                            "nullable": true
+                                          },
+                                          "name": {
+                                            "description": "The name of the attribute",
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "description": "The path in the body",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "header": {
+                                      "description": "Forward header values as custom attributes/labels in metrics",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Configuration to forward header values in metric labels",
+                                        "anyOf": [
+                                          {
+                                            "description": "Match via header name",
+                                            "type": "object",
+                                            "required": [
+                                              "named"
+                                            ],
+                                            "properties": {
+                                              "default": {
+                                                "description": "The optional default value",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "bool values",
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "description": "i64 values",
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  },
+                                                  {
+                                                    "description": "f64 values",
+                                                    "type": "number",
+                                                    "format": "double"
+                                                  },
+                                                  {
+                                                    "description": "String values",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "description": "Array of homogeneous values",
+                                                    "anyOf": [
+                                                      {
+                                                        "description": "Array of bools",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      {
+                                                        "description": "Array of integers",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "integer",
+                                                          "format": "int64"
+                                                        }
+                                                      },
+                                                      {
+                                                        "description": "Array of floats",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "number",
+                                                          "format": "double"
+                                                        }
+                                                      },
+                                                      {
+                                                        "description": "Array of strings",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ],
+                                                "nullable": true
+                                              },
+                                              "named": {
+                                                "description": "The name of the header",
+                                                "type": "string"
+                                              },
+                                              "rename": {
+                                                "description": "The optional output name",
+                                                "type": "string",
+                                                "nullable": true
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "description": "Match via rgex",
+                                            "type": "object",
+                                            "required": [
+                                              "matching"
+                                            ],
+                                            "properties": {
+                                              "matching": {
+                                                "description": "Using a regex on the header name",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "response": {
+                                  "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
+                                  "type": "object",
+                                  "properties": {
+                                    "body": {
+                                      "description": "Forward body values as custom attributes/labels in metrics",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Configuration to forward body values in metric attributes/labels",
+                                        "type": "object",
+                                        "required": [
+                                          "name",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "default": {
+                                            "description": "The optional default value",
+                                            "anyOf": [
+                                              {
+                                                "description": "bool values",
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "description": "i64 values",
+                                                "type": "integer",
+                                                "format": "int64"
+                                              },
+                                              {
+                                                "description": "f64 values",
+                                                "type": "number",
+                                                "format": "double"
+                                              },
+                                              {
+                                                "description": "String values",
+                                                "type": "string"
+                                              },
+                                              {
+                                                "description": "Array of homogeneous values",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "Array of bools",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of integers",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer",
+                                                      "format": "int64"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of floats",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number",
+                                                      "format": "double"
+                                                    }
+                                                  },
+                                                  {
+                                                    "description": "Array of strings",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            ],
+                                            "nullable": true
+                                          },
+                                          "name": {
+                                            "description": "The name of the attribute",
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "description": "The path in the body",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "header": {
+                                      "description": "Forward header values as custom attributes/labels in metrics",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Configuration to forward header values in metric labels",
+                                        "anyOf": [
+                                          {
+                                            "description": "Match via header name",
+                                            "type": "object",
+                                            "required": [
+                                              "named"
+                                            ],
+                                            "properties": {
+                                              "default": {
+                                                "description": "The optional default value",
+                                                "anyOf": [
+                                                  {
+                                                    "description": "bool values",
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "description": "i64 values",
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  },
+                                                  {
+                                                    "description": "f64 values",
+                                                    "type": "number",
+                                                    "format": "double"
+                                                  },
+                                                  {
+                                                    "description": "String values",
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "description": "Array of homogeneous values",
+                                                    "anyOf": [
+                                                      {
+                                                        "description": "Array of bools",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "boolean"
+                                                        }
+                                                      },
+                                                      {
+                                                        "description": "Array of integers",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "integer",
+                                                          "format": "int64"
+                                                        }
+                                                      },
+                                                      {
+                                                        "description": "Array of floats",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "number",
+                                                          "format": "double"
+                                                        }
+                                                      },
+                                                      {
+                                                        "description": "Array of strings",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ],
+                                                "nullable": true
+                                              },
+                                              "named": {
+                                                "description": "The name of the header",
+                                                "type": "string"
+                                              },
+                                              "rename": {
+                                                "description": "The optional output name",
+                                                "type": "string",
+                                                "nullable": true
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "description": "Match via rgex",
+                                            "type": "object",
+                                            "required": [
+                                              "matching"
+                                            ],
+                                            "properties": {
+                                              "matching": {
+                                                "description": "Using a regex on the header name",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "static": {
+                                  "description": "Configuration to insert custom attributes/labels in metrics",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Configuration to insert custom attributes/labels in metrics",
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "description": "The name of the attribute to insert",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The value of the attribute to insert",
+                                        "anyOf": [
+                                          {
+                                            "description": "bool values",
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "description": "i64 values",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          {
+                                            "description": "f64 values",
+                                            "type": "number",
+                                            "format": "double"
+                                          },
+                                          {
+                                            "description": "String values",
+                                            "type": "string"
+                                          },
+                                          {
+                                            "description": "Array of homogeneous values",
+                                            "anyOf": [
+                                              {
+                                                "description": "Array of bools",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of integers",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of floats",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number",
+                                                  "format": "double"
+                                                }
+                                              },
+                                              {
+                                                "description": "Array of strings",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "subgraphs": {
+                              "description": "Attributes per subgraph",
+                              "type": "object",
+                              "additionalProperties": {
+                                "description": "Configuration to add custom attributes/labels on metrics to subgraphs",
+                                "type": "object",
+                                "properties": {
+                                  "context": {
+                                    "description": "Configuration to forward values from the context to custom attributes/labels in metrics",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Configuration to forward context values in metric attributes/labels",
+                                      "type": "object",
+                                      "required": [
+                                        "named"
+                                      ],
+                                      "properties": {
+                                        "default": {
+                                          "description": "The optional default value",
+                                          "anyOf": [
+                                            {
+                                              "description": "bool values",
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "description": "i64 values",
+                                              "type": "integer",
+                                              "format": "int64"
+                                            },
+                                            {
+                                              "description": "f64 values",
+                                              "type": "number",
+                                              "format": "double"
+                                            },
+                                            {
+                                              "description": "String values",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "description": "Array of homogeneous values",
+                                              "anyOf": [
+                                                {
+                                                  "description": "Array of bools",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of integers",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of floats",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number",
+                                                    "format": "double"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of strings",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "nullable": true
+                                        },
+                                        "named": {
+                                          "description": "The name of the value in the context",
+                                          "type": "string"
+                                        },
+                                        "rename": {
+                                          "description": "The optional output name",
+                                          "type": "string",
+                                          "nullable": true
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "errors": {
+                                    "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
+                                    "type": "object",
+                                    "properties": {
+                                      "extensions": {
+                                        "description": "Forward extensions values as custom attributes/labels in metrics",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Configuration to forward body values in metric attributes/labels",
+                                          "type": "object",
+                                          "required": [
+                                            "name",
+                                            "path"
+                                          ],
+                                          "properties": {
+                                            "default": {
+                                              "description": "The optional default value",
+                                              "anyOf": [
+                                                {
+                                                  "description": "bool values",
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "description": "i64 values",
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                },
+                                                {
+                                                  "description": "f64 values",
+                                                  "type": "number",
+                                                  "format": "double"
+                                                },
+                                                {
+                                                  "description": "String values",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "description": "Array of homogeneous values",
+                                                  "anyOf": [
+                                                    {
+                                                      "description": "Array of bools",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of integers",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of floats",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "number",
+                                                        "format": "double"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of strings",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "nullable": true
+                                            },
+                                            "name": {
+                                              "description": "The name of the attribute",
+                                              "type": "string"
+                                            },
+                                            "path": {
+                                              "description": "The path in the body",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "include_messages": {
+                                        "description": "Will include the error message in a \"message\" attribute",
+                                        "default": null,
+                                        "type": "boolean",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "request": {
+                                    "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
+                                    "type": "object",
+                                    "properties": {
+                                      "body": {
+                                        "description": "Forward body values as custom attributes/labels in metrics",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Configuration to forward body values in metric attributes/labels",
+                                          "type": "object",
+                                          "required": [
+                                            "name",
+                                            "path"
+                                          ],
+                                          "properties": {
+                                            "default": {
+                                              "description": "The optional default value",
+                                              "anyOf": [
+                                                {
+                                                  "description": "bool values",
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "description": "i64 values",
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                },
+                                                {
+                                                  "description": "f64 values",
+                                                  "type": "number",
+                                                  "format": "double"
+                                                },
+                                                {
+                                                  "description": "String values",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "description": "Array of homogeneous values",
+                                                  "anyOf": [
+                                                    {
+                                                      "description": "Array of bools",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of integers",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of floats",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "number",
+                                                        "format": "double"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of strings",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "nullable": true
+                                            },
+                                            "name": {
+                                              "description": "The name of the attribute",
+                                              "type": "string"
+                                            },
+                                            "path": {
+                                              "description": "The path in the body",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "header": {
+                                        "description": "Forward header values as custom attributes/labels in metrics",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Configuration to forward header values in metric labels",
+                                          "anyOf": [
+                                            {
+                                              "description": "Match via header name",
+                                              "type": "object",
+                                              "required": [
+                                                "named"
+                                              ],
+                                              "properties": {
+                                                "default": {
+                                                  "description": "The optional default value",
+                                                  "anyOf": [
+                                                    {
+                                                      "description": "bool values",
+                                                      "type": "boolean"
+                                                    },
+                                                    {
+                                                      "description": "i64 values",
+                                                      "type": "integer",
+                                                      "format": "int64"
+                                                    },
+                                                    {
+                                                      "description": "f64 values",
+                                                      "type": "number",
+                                                      "format": "double"
+                                                    },
+                                                    {
+                                                      "description": "String values",
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "description": "Array of homogeneous values",
+                                                      "anyOf": [
+                                                        {
+                                                          "description": "Array of bools",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        {
+                                                          "description": "Array of integers",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "integer",
+                                                            "format": "int64"
+                                                          }
+                                                        },
+                                                        {
+                                                          "description": "Array of floats",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number",
+                                                            "format": "double"
+                                                          }
+                                                        },
+                                                        {
+                                                          "description": "Array of strings",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "nullable": true
+                                                },
+                                                "named": {
+                                                  "description": "The name of the header",
+                                                  "type": "string"
+                                                },
+                                                "rename": {
+                                                  "description": "The optional output name",
+                                                  "type": "string",
+                                                  "nullable": true
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "description": "Match via rgex",
+                                              "type": "object",
+                                              "required": [
+                                                "matching"
+                                              ],
+                                              "properties": {
+                                                "matching": {
+                                                  "description": "Using a regex on the header name",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "response": {
+                                    "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
+                                    "type": "object",
+                                    "properties": {
+                                      "body": {
+                                        "description": "Forward body values as custom attributes/labels in metrics",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Configuration to forward body values in metric attributes/labels",
+                                          "type": "object",
+                                          "required": [
+                                            "name",
+                                            "path"
+                                          ],
+                                          "properties": {
+                                            "default": {
+                                              "description": "The optional default value",
+                                              "anyOf": [
+                                                {
+                                                  "description": "bool values",
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "description": "i64 values",
+                                                  "type": "integer",
+                                                  "format": "int64"
+                                                },
+                                                {
+                                                  "description": "f64 values",
+                                                  "type": "number",
+                                                  "format": "double"
+                                                },
+                                                {
+                                                  "description": "String values",
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "description": "Array of homogeneous values",
+                                                  "anyOf": [
+                                                    {
+                                                      "description": "Array of bools",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of integers",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "integer",
+                                                        "format": "int64"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of floats",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "number",
+                                                        "format": "double"
+                                                      }
+                                                    },
+                                                    {
+                                                      "description": "Array of strings",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ],
+                                              "nullable": true
+                                            },
+                                            "name": {
+                                              "description": "The name of the attribute",
+                                              "type": "string"
+                                            },
+                                            "path": {
+                                              "description": "The path in the body",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "header": {
+                                        "description": "Forward header values as custom attributes/labels in metrics",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Configuration to forward header values in metric labels",
+                                          "anyOf": [
+                                            {
+                                              "description": "Match via header name",
+                                              "type": "object",
+                                              "required": [
+                                                "named"
+                                              ],
+                                              "properties": {
+                                                "default": {
+                                                  "description": "The optional default value",
+                                                  "anyOf": [
+                                                    {
+                                                      "description": "bool values",
+                                                      "type": "boolean"
+                                                    },
+                                                    {
+                                                      "description": "i64 values",
+                                                      "type": "integer",
+                                                      "format": "int64"
+                                                    },
+                                                    {
+                                                      "description": "f64 values",
+                                                      "type": "number",
+                                                      "format": "double"
+                                                    },
+                                                    {
+                                                      "description": "String values",
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "description": "Array of homogeneous values",
+                                                      "anyOf": [
+                                                        {
+                                                          "description": "Array of bools",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "boolean"
+                                                          }
+                                                        },
+                                                        {
+                                                          "description": "Array of integers",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "integer",
+                                                            "format": "int64"
+                                                          }
+                                                        },
+                                                        {
+                                                          "description": "Array of floats",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number",
+                                                            "format": "double"
+                                                          }
+                                                        },
+                                                        {
+                                                          "description": "Array of strings",
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  ],
+                                                  "nullable": true
+                                                },
+                                                "named": {
+                                                  "description": "The name of the header",
+                                                  "type": "string"
+                                                },
+                                                "rename": {
+                                                  "description": "The optional output name",
+                                                  "type": "string",
+                                                  "nullable": true
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "description": "Match via rgex",
+                                              "type": "object",
+                                              "required": [
+                                                "matching"
+                                              ],
+                                              "properties": {
+                                                "matching": {
+                                                  "description": "Using a regex on the header name",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "static": {
+                                    "description": "Configuration to insert custom attributes/labels in metrics",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Configuration to insert custom attributes/labels in metrics",
+                                      "type": "object",
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The name of the attribute to insert",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The value of the attribute to insert",
+                                          "anyOf": [
+                                            {
+                                              "description": "bool values",
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "description": "i64 values",
+                                              "type": "integer",
+                                              "format": "int64"
+                                            },
+                                            {
+                                              "description": "f64 values",
+                                              "type": "number",
+                                              "format": "double"
+                                            },
+                                            {
+                                              "description": "String values",
+                                              "type": "string"
+                                            },
+                                            {
+                                              "description": "Array of homogeneous values",
+                                              "anyOf": [
+                                                {
+                                                  "description": "Array of bools",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of integers",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of floats",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "number",
+                                                    "format": "double"
+                                                  }
+                                                },
+                                                {
+                                                  "description": "Array of strings",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "supergraph": {
+                          "description": "Configuration to forward header values or body values from router request/response in metric attributes/labels",
                           "type": "object",
                           "properties": {
                             "context": {
@@ -1826,8 +4143,7 @@
                                   }
                                 },
                                 "additionalProperties": false
-                              },
-                              "nullable": true
+                              }
                             },
                             "errors": {
                               "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
@@ -1913,17 +4229,16 @@
                                       }
                                     },
                                     "additionalProperties": false
-                                  },
-                                  "nullable": true
+                                  }
                                 },
                                 "include_messages": {
                                   "description": "Will include the error message in a \"message\" attribute",
-                                  "default": false,
-                                  "type": "boolean"
+                                  "default": null,
+                                  "type": "boolean",
+                                  "nullable": true
                                 }
                               },
-                              "additionalProperties": false,
-                              "nullable": true
+                              "additionalProperties": false
                             },
                             "request": {
                               "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
@@ -2009,8 +4324,7 @@
                                       }
                                     },
                                     "additionalProperties": false
-                                  },
-                                  "nullable": true
+                                  }
                                 },
                                 "header": {
                                   "description": "Forward header values as custom attributes/labels in metrics",
@@ -2111,12 +4425,10 @@
                                         "additionalProperties": false
                                       }
                                     ]
-                                  },
-                                  "nullable": true
+                                  }
                                 }
                               },
-                              "additionalProperties": false,
-                              "nullable": true
+                              "additionalProperties": false
                             },
                             "response": {
                               "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
@@ -2202,8 +4514,7 @@
                                       }
                                     },
                                     "additionalProperties": false
-                                  },
-                                  "nullable": true
+                                  }
                                 },
                                 "header": {
                                   "description": "Forward header values as custom attributes/labels in metrics",
@@ -2304,12 +4615,10 @@
                                         "additionalProperties": false
                                       }
                                     ]
-                                  },
-                                  "nullable": true
+                                  }
                                 }
                               },
-                              "additionalProperties": false,
-                              "nullable": true
+                              "additionalProperties": false
                             },
                             "static": {
                               "description": "Configuration to insert custom attributes/labels in metrics",
@@ -2386,2236 +4695,2739 @@
                                   }
                                 },
                                 "additionalProperties": false
-                              },
-                              "nullable": true
-                            }
-                          },
-                          "additionalProperties": false,
-                          "nullable": true
-                        },
-                        "subgraphs": {
-                          "description": "Attributes per subgraph",
-                          "type": "object",
-                          "additionalProperties": {
-                            "description": "Configuration to add custom attributes/labels on metrics to subgraphs",
-                            "type": "object",
-                            "properties": {
-                              "context": {
-                                "description": "Configuration to forward values from the context to custom attributes/labels in metrics",
-                                "type": "array",
-                                "items": {
-                                  "description": "Configuration to forward context values in metric attributes/labels",
-                                  "type": "object",
-                                  "required": [
-                                    "named"
-                                  ],
-                                  "properties": {
-                                    "default": {
-                                      "description": "The optional default value",
-                                      "anyOf": [
-                                        {
-                                          "description": "bool values",
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "description": "i64 values",
-                                          "type": "integer",
-                                          "format": "int64"
-                                        },
-                                        {
-                                          "description": "f64 values",
-                                          "type": "number",
-                                          "format": "double"
-                                        },
-                                        {
-                                          "description": "String values",
-                                          "type": "string"
-                                        },
-                                        {
-                                          "description": "Array of homogeneous values",
-                                          "anyOf": [
-                                            {
-                                              "description": "Array of bools",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "boolean"
-                                              }
-                                            },
-                                            {
-                                              "description": "Array of integers",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "integer",
-                                                "format": "int64"
-                                              }
-                                            },
-                                            {
-                                              "description": "Array of floats",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "number",
-                                                "format": "double"
-                                              }
-                                            },
-                                            {
-                                              "description": "Array of strings",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "string"
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      ],
-                                      "nullable": true
-                                    },
-                                    "named": {
-                                      "description": "The name of the value in the context",
-                                      "type": "string"
-                                    },
-                                    "rename": {
-                                      "description": "The optional output name",
-                                      "type": "string",
-                                      "nullable": true
-                                    }
-                                  },
-                                  "additionalProperties": false
-                                },
-                                "nullable": true
-                              },
-                              "errors": {
-                                "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
-                                "type": "object",
-                                "properties": {
-                                  "extensions": {
-                                    "description": "Forward extensions values as custom attributes/labels in metrics",
-                                    "type": "array",
-                                    "items": {
-                                      "description": "Configuration to forward body values in metric attributes/labels",
-                                      "type": "object",
-                                      "required": [
-                                        "name",
-                                        "path"
-                                      ],
-                                      "properties": {
-                                        "default": {
-                                          "description": "The optional default value",
-                                          "anyOf": [
-                                            {
-                                              "description": "bool values",
-                                              "type": "boolean"
-                                            },
-                                            {
-                                              "description": "i64 values",
-                                              "type": "integer",
-                                              "format": "int64"
-                                            },
-                                            {
-                                              "description": "f64 values",
-                                              "type": "number",
-                                              "format": "double"
-                                            },
-                                            {
-                                              "description": "String values",
-                                              "type": "string"
-                                            },
-                                            {
-                                              "description": "Array of homogeneous values",
-                                              "anyOf": [
-                                                {
-                                                  "description": "Array of bools",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "boolean"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of integers",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "integer",
-                                                    "format": "int64"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of floats",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "number",
-                                                    "format": "double"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of strings",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "nullable": true
-                                        },
-                                        "name": {
-                                          "description": "The name of the attribute",
-                                          "type": "string"
-                                        },
-                                        "path": {
-                                          "description": "The path in the body",
-                                          "type": "string"
-                                        }
-                                      },
-                                      "additionalProperties": false
-                                    },
-                                    "nullable": true
-                                  },
-                                  "include_messages": {
-                                    "description": "Will include the error message in a \"message\" attribute",
-                                    "default": false,
-                                    "type": "boolean"
-                                  }
-                                },
-                                "additionalProperties": false,
-                                "nullable": true
-                              },
-                              "request": {
-                                "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
-                                "type": "object",
-                                "properties": {
-                                  "body": {
-                                    "description": "Forward body values as custom attributes/labels in metrics",
-                                    "type": "array",
-                                    "items": {
-                                      "description": "Configuration to forward body values in metric attributes/labels",
-                                      "type": "object",
-                                      "required": [
-                                        "name",
-                                        "path"
-                                      ],
-                                      "properties": {
-                                        "default": {
-                                          "description": "The optional default value",
-                                          "anyOf": [
-                                            {
-                                              "description": "bool values",
-                                              "type": "boolean"
-                                            },
-                                            {
-                                              "description": "i64 values",
-                                              "type": "integer",
-                                              "format": "int64"
-                                            },
-                                            {
-                                              "description": "f64 values",
-                                              "type": "number",
-                                              "format": "double"
-                                            },
-                                            {
-                                              "description": "String values",
-                                              "type": "string"
-                                            },
-                                            {
-                                              "description": "Array of homogeneous values",
-                                              "anyOf": [
-                                                {
-                                                  "description": "Array of bools",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "boolean"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of integers",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "integer",
-                                                    "format": "int64"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of floats",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "number",
-                                                    "format": "double"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of strings",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "nullable": true
-                                        },
-                                        "name": {
-                                          "description": "The name of the attribute",
-                                          "type": "string"
-                                        },
-                                        "path": {
-                                          "description": "The path in the body",
-                                          "type": "string"
-                                        }
-                                      },
-                                      "additionalProperties": false
-                                    },
-                                    "nullable": true
-                                  },
-                                  "header": {
-                                    "description": "Forward header values as custom attributes/labels in metrics",
-                                    "type": "array",
-                                    "items": {
-                                      "description": "Configuration to forward header values in metric labels",
-                                      "anyOf": [
-                                        {
-                                          "description": "Match via header name",
-                                          "type": "object",
-                                          "required": [
-                                            "named"
-                                          ],
-                                          "properties": {
-                                            "default": {
-                                              "description": "The optional default value",
-                                              "anyOf": [
-                                                {
-                                                  "description": "bool values",
-                                                  "type": "boolean"
-                                                },
-                                                {
-                                                  "description": "i64 values",
-                                                  "type": "integer",
-                                                  "format": "int64"
-                                                },
-                                                {
-                                                  "description": "f64 values",
-                                                  "type": "number",
-                                                  "format": "double"
-                                                },
-                                                {
-                                                  "description": "String values",
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "description": "Array of homogeneous values",
-                                                  "anyOf": [
-                                                    {
-                                                      "description": "Array of bools",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "boolean"
-                                                      }
-                                                    },
-                                                    {
-                                                      "description": "Array of integers",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "integer",
-                                                        "format": "int64"
-                                                      }
-                                                    },
-                                                    {
-                                                      "description": "Array of floats",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "number",
-                                                        "format": "double"
-                                                      }
-                                                    },
-                                                    {
-                                                      "description": "Array of strings",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "string"
-                                                      }
-                                                    }
-                                                  ]
-                                                }
-                                              ],
-                                              "nullable": true
-                                            },
-                                            "named": {
-                                              "description": "The name of the header",
-                                              "type": "string"
-                                            },
-                                            "rename": {
-                                              "description": "The optional output name",
-                                              "type": "string",
-                                              "nullable": true
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "description": "Match via rgex",
-                                          "type": "object",
-                                          "required": [
-                                            "matching"
-                                          ],
-                                          "properties": {
-                                            "matching": {
-                                              "description": "Using a regex on the header name",
-                                              "type": "string"
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "nullable": true
-                                  }
-                                },
-                                "additionalProperties": false,
-                                "nullable": true
-                              },
-                              "response": {
-                                "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
-                                "type": "object",
-                                "properties": {
-                                  "body": {
-                                    "description": "Forward body values as custom attributes/labels in metrics",
-                                    "type": "array",
-                                    "items": {
-                                      "description": "Configuration to forward body values in metric attributes/labels",
-                                      "type": "object",
-                                      "required": [
-                                        "name",
-                                        "path"
-                                      ],
-                                      "properties": {
-                                        "default": {
-                                          "description": "The optional default value",
-                                          "anyOf": [
-                                            {
-                                              "description": "bool values",
-                                              "type": "boolean"
-                                            },
-                                            {
-                                              "description": "i64 values",
-                                              "type": "integer",
-                                              "format": "int64"
-                                            },
-                                            {
-                                              "description": "f64 values",
-                                              "type": "number",
-                                              "format": "double"
-                                            },
-                                            {
-                                              "description": "String values",
-                                              "type": "string"
-                                            },
-                                            {
-                                              "description": "Array of homogeneous values",
-                                              "anyOf": [
-                                                {
-                                                  "description": "Array of bools",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "boolean"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of integers",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "integer",
-                                                    "format": "int64"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of floats",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "number",
-                                                    "format": "double"
-                                                  }
-                                                },
-                                                {
-                                                  "description": "Array of strings",
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "nullable": true
-                                        },
-                                        "name": {
-                                          "description": "The name of the attribute",
-                                          "type": "string"
-                                        },
-                                        "path": {
-                                          "description": "The path in the body",
-                                          "type": "string"
-                                        }
-                                      },
-                                      "additionalProperties": false
-                                    },
-                                    "nullable": true
-                                  },
-                                  "header": {
-                                    "description": "Forward header values as custom attributes/labels in metrics",
-                                    "type": "array",
-                                    "items": {
-                                      "description": "Configuration to forward header values in metric labels",
-                                      "anyOf": [
-                                        {
-                                          "description": "Match via header name",
-                                          "type": "object",
-                                          "required": [
-                                            "named"
-                                          ],
-                                          "properties": {
-                                            "default": {
-                                              "description": "The optional default value",
-                                              "anyOf": [
-                                                {
-                                                  "description": "bool values",
-                                                  "type": "boolean"
-                                                },
-                                                {
-                                                  "description": "i64 values",
-                                                  "type": "integer",
-                                                  "format": "int64"
-                                                },
-                                                {
-                                                  "description": "f64 values",
-                                                  "type": "number",
-                                                  "format": "double"
-                                                },
-                                                {
-                                                  "description": "String values",
-                                                  "type": "string"
-                                                },
-                                                {
-                                                  "description": "Array of homogeneous values",
-                                                  "anyOf": [
-                                                    {
-                                                      "description": "Array of bools",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "boolean"
-                                                      }
-                                                    },
-                                                    {
-                                                      "description": "Array of integers",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "integer",
-                                                        "format": "int64"
-                                                      }
-                                                    },
-                                                    {
-                                                      "description": "Array of floats",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "number",
-                                                        "format": "double"
-                                                      }
-                                                    },
-                                                    {
-                                                      "description": "Array of strings",
-                                                      "type": "array",
-                                                      "items": {
-                                                        "type": "string"
-                                                      }
-                                                    }
-                                                  ]
-                                                }
-                                              ],
-                                              "nullable": true
-                                            },
-                                            "named": {
-                                              "description": "The name of the header",
-                                              "type": "string"
-                                            },
-                                            "rename": {
-                                              "description": "The optional output name",
-                                              "type": "string",
-                                              "nullable": true
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        },
-                                        {
-                                          "description": "Match via rgex",
-                                          "type": "object",
-                                          "required": [
-                                            "matching"
-                                          ],
-                                          "properties": {
-                                            "matching": {
-                                              "description": "Using a regex on the header name",
-                                              "type": "string"
-                                            }
-                                          },
-                                          "additionalProperties": false
-                                        }
-                                      ]
-                                    },
-                                    "nullable": true
-                                  }
-                                },
-                                "additionalProperties": false,
-                                "nullable": true
-                              },
-                              "static": {
-                                "description": "Configuration to insert custom attributes/labels in metrics",
-                                "type": "array",
-                                "items": {
-                                  "description": "Configuration to insert custom attributes/labels in metrics",
-                                  "type": "object",
-                                  "required": [
-                                    "name",
-                                    "value"
-                                  ],
-                                  "properties": {
-                                    "name": {
-                                      "description": "The name of the attribute to insert",
-                                      "type": "string"
-                                    },
-                                    "value": {
-                                      "description": "The value of the attribute to insert",
-                                      "anyOf": [
-                                        {
-                                          "description": "bool values",
-                                          "type": "boolean"
-                                        },
-                                        {
-                                          "description": "i64 values",
-                                          "type": "integer",
-                                          "format": "int64"
-                                        },
-                                        {
-                                          "description": "f64 values",
-                                          "type": "number",
-                                          "format": "double"
-                                        },
-                                        {
-                                          "description": "String values",
-                                          "type": "string"
-                                        },
-                                        {
-                                          "description": "Array of homogeneous values",
-                                          "anyOf": [
-                                            {
-                                              "description": "Array of bools",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "boolean"
-                                              }
-                                            },
-                                            {
-                                              "description": "Array of integers",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "integer",
-                                                "format": "int64"
-                                              }
-                                            },
-                                            {
-                                              "description": "Array of floats",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "number",
-                                                "format": "double"
-                                              }
-                                            },
-                                            {
-                                              "description": "Array of strings",
-                                              "type": "array",
-                                              "items": {
-                                                "type": "string"
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  },
-                                  "additionalProperties": false
-                                },
-                                "nullable": true
                               }
-                            },
-                            "additionalProperties": false
-                          },
-                          "nullable": true
-                        }
-                      },
-                      "additionalProperties": false,
-                      "nullable": true
-                    },
-                    "supergraph": {
-                      "description": "Configuration to forward header values or body values from router request/response in metric attributes/labels",
-                      "type": "object",
-                      "properties": {
-                        "context": {
-                          "description": "Configuration to forward values from the context to custom attributes/labels in metrics",
-                          "type": "array",
-                          "items": {
-                            "description": "Configuration to forward context values in metric attributes/labels",
-                            "type": "object",
-                            "required": [
-                              "named"
-                            ],
-                            "properties": {
-                              "default": {
-                                "description": "The optional default value",
-                                "anyOf": [
-                                  {
-                                    "description": "bool values",
-                                    "type": "boolean"
-                                  },
-                                  {
-                                    "description": "i64 values",
-                                    "type": "integer",
-                                    "format": "int64"
-                                  },
-                                  {
-                                    "description": "f64 values",
-                                    "type": "number",
-                                    "format": "double"
-                                  },
-                                  {
-                                    "description": "String values",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "description": "Array of homogeneous values",
-                                    "anyOf": [
-                                      {
-                                        "description": "Array of bools",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      {
-                                        "description": "Array of integers",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "integer",
-                                          "format": "int64"
-                                        }
-                                      },
-                                      {
-                                        "description": "Array of floats",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "number",
-                                          "format": "double"
-                                        }
-                                      },
-                                      {
-                                        "description": "Array of strings",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    ]
-                                  }
-                                ],
-                                "nullable": true
-                              },
-                              "named": {
-                                "description": "The name of the value in the context",
-                                "type": "string"
-                              },
-                              "rename": {
-                                "description": "The optional output name",
-                                "type": "string",
-                                "nullable": true
-                              }
-                            },
-                            "additionalProperties": false
-                          },
-                          "nullable": true
-                        },
-                        "errors": {
-                          "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
-                          "type": "object",
-                          "properties": {
-                            "extensions": {
-                              "description": "Forward extensions values as custom attributes/labels in metrics",
-                              "type": "array",
-                              "items": {
-                                "description": "Configuration to forward body values in metric attributes/labels",
-                                "type": "object",
-                                "required": [
-                                  "name",
-                                  "path"
-                                ],
-                                "properties": {
-                                  "default": {
-                                    "description": "The optional default value",
-                                    "anyOf": [
-                                      {
-                                        "description": "bool values",
-                                        "type": "boolean"
-                                      },
-                                      {
-                                        "description": "i64 values",
-                                        "type": "integer",
-                                        "format": "int64"
-                                      },
-                                      {
-                                        "description": "f64 values",
-                                        "type": "number",
-                                        "format": "double"
-                                      },
-                                      {
-                                        "description": "String values",
-                                        "type": "string"
-                                      },
-                                      {
-                                        "description": "Array of homogeneous values",
-                                        "anyOf": [
-                                          {
-                                            "description": "Array of bools",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "boolean"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of integers",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "integer",
-                                              "format": "int64"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of floats",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "number",
-                                              "format": "double"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of strings",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    ],
-                                    "nullable": true
-                                  },
-                                  "name": {
-                                    "description": "The name of the attribute",
-                                    "type": "string"
-                                  },
-                                  "path": {
-                                    "description": "The path in the body",
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false
-                              },
-                              "nullable": true
-                            },
-                            "include_messages": {
-                              "description": "Will include the error message in a \"message\" attribute",
-                              "default": false,
-                              "type": "boolean"
                             }
                           },
-                          "additionalProperties": false,
-                          "nullable": true
-                        },
-                        "request": {
-                          "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
-                          "type": "object",
-                          "properties": {
-                            "body": {
-                              "description": "Forward body values as custom attributes/labels in metrics",
-                              "type": "array",
-                              "items": {
-                                "description": "Configuration to forward body values in metric attributes/labels",
-                                "type": "object",
-                                "required": [
-                                  "name",
-                                  "path"
-                                ],
-                                "properties": {
-                                  "default": {
-                                    "description": "The optional default value",
-                                    "anyOf": [
-                                      {
-                                        "description": "bool values",
-                                        "type": "boolean"
-                                      },
-                                      {
-                                        "description": "i64 values",
-                                        "type": "integer",
-                                        "format": "int64"
-                                      },
-                                      {
-                                        "description": "f64 values",
-                                        "type": "number",
-                                        "format": "double"
-                                      },
-                                      {
-                                        "description": "String values",
-                                        "type": "string"
-                                      },
-                                      {
-                                        "description": "Array of homogeneous values",
-                                        "anyOf": [
-                                          {
-                                            "description": "Array of bools",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "boolean"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of integers",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "integer",
-                                              "format": "int64"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of floats",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "number",
-                                              "format": "double"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of strings",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    ],
-                                    "nullable": true
-                                  },
-                                  "name": {
-                                    "description": "The name of the attribute",
-                                    "type": "string"
-                                  },
-                                  "path": {
-                                    "description": "The path in the body",
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false
-                              },
-                              "nullable": true
-                            },
-                            "header": {
-                              "description": "Forward header values as custom attributes/labels in metrics",
-                              "type": "array",
-                              "items": {
-                                "description": "Configuration to forward header values in metric labels",
-                                "anyOf": [
-                                  {
-                                    "description": "Match via header name",
-                                    "type": "object",
-                                    "required": [
-                                      "named"
-                                    ],
-                                    "properties": {
-                                      "default": {
-                                        "description": "The optional default value",
-                                        "anyOf": [
-                                          {
-                                            "description": "bool values",
-                                            "type": "boolean"
-                                          },
-                                          {
-                                            "description": "i64 values",
-                                            "type": "integer",
-                                            "format": "int64"
-                                          },
-                                          {
-                                            "description": "f64 values",
-                                            "type": "number",
-                                            "format": "double"
-                                          },
-                                          {
-                                            "description": "String values",
-                                            "type": "string"
-                                          },
-                                          {
-                                            "description": "Array of homogeneous values",
-                                            "anyOf": [
-                                              {
-                                                "description": "Array of bools",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "boolean"
-                                                }
-                                              },
-                                              {
-                                                "description": "Array of integers",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "integer",
-                                                  "format": "int64"
-                                                }
-                                              },
-                                              {
-                                                "description": "Array of floats",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "number",
-                                                  "format": "double"
-                                                }
-                                              },
-                                              {
-                                                "description": "Array of strings",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        ],
-                                        "nullable": true
-                                      },
-                                      "named": {
-                                        "description": "The name of the header",
-                                        "type": "string"
-                                      },
-                                      "rename": {
-                                        "description": "The optional output name",
-                                        "type": "string",
-                                        "nullable": true
-                                      }
-                                    },
-                                    "additionalProperties": false
-                                  },
-                                  {
-                                    "description": "Match via rgex",
-                                    "type": "object",
-                                    "required": [
-                                      "matching"
-                                    ],
-                                    "properties": {
-                                      "matching": {
-                                        "description": "Using a regex on the header name",
-                                        "type": "string"
-                                      }
-                                    },
-                                    "additionalProperties": false
-                                  }
-                                ]
-                              },
-                              "nullable": true
-                            }
-                          },
-                          "additionalProperties": false,
-                          "nullable": true
-                        },
-                        "response": {
-                          "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
-                          "type": "object",
-                          "properties": {
-                            "body": {
-                              "description": "Forward body values as custom attributes/labels in metrics",
-                              "type": "array",
-                              "items": {
-                                "description": "Configuration to forward body values in metric attributes/labels",
-                                "type": "object",
-                                "required": [
-                                  "name",
-                                  "path"
-                                ],
-                                "properties": {
-                                  "default": {
-                                    "description": "The optional default value",
-                                    "anyOf": [
-                                      {
-                                        "description": "bool values",
-                                        "type": "boolean"
-                                      },
-                                      {
-                                        "description": "i64 values",
-                                        "type": "integer",
-                                        "format": "int64"
-                                      },
-                                      {
-                                        "description": "f64 values",
-                                        "type": "number",
-                                        "format": "double"
-                                      },
-                                      {
-                                        "description": "String values",
-                                        "type": "string"
-                                      },
-                                      {
-                                        "description": "Array of homogeneous values",
-                                        "anyOf": [
-                                          {
-                                            "description": "Array of bools",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "boolean"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of integers",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "integer",
-                                              "format": "int64"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of floats",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "number",
-                                              "format": "double"
-                                            }
-                                          },
-                                          {
-                                            "description": "Array of strings",
-                                            "type": "array",
-                                            "items": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    ],
-                                    "nullable": true
-                                  },
-                                  "name": {
-                                    "description": "The name of the attribute",
-                                    "type": "string"
-                                  },
-                                  "path": {
-                                    "description": "The path in the body",
-                                    "type": "string"
-                                  }
-                                },
-                                "additionalProperties": false
-                              },
-                              "nullable": true
-                            },
-                            "header": {
-                              "description": "Forward header values as custom attributes/labels in metrics",
-                              "type": "array",
-                              "items": {
-                                "description": "Configuration to forward header values in metric labels",
-                                "anyOf": [
-                                  {
-                                    "description": "Match via header name",
-                                    "type": "object",
-                                    "required": [
-                                      "named"
-                                    ],
-                                    "properties": {
-                                      "default": {
-                                        "description": "The optional default value",
-                                        "anyOf": [
-                                          {
-                                            "description": "bool values",
-                                            "type": "boolean"
-                                          },
-                                          {
-                                            "description": "i64 values",
-                                            "type": "integer",
-                                            "format": "int64"
-                                          },
-                                          {
-                                            "description": "f64 values",
-                                            "type": "number",
-                                            "format": "double"
-                                          },
-                                          {
-                                            "description": "String values",
-                                            "type": "string"
-                                          },
-                                          {
-                                            "description": "Array of homogeneous values",
-                                            "anyOf": [
-                                              {
-                                                "description": "Array of bools",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "boolean"
-                                                }
-                                              },
-                                              {
-                                                "description": "Array of integers",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "integer",
-                                                  "format": "int64"
-                                                }
-                                              },
-                                              {
-                                                "description": "Array of floats",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "number",
-                                                  "format": "double"
-                                                }
-                                              },
-                                              {
-                                                "description": "Array of strings",
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            ]
-                                          }
-                                        ],
-                                        "nullable": true
-                                      },
-                                      "named": {
-                                        "description": "The name of the header",
-                                        "type": "string"
-                                      },
-                                      "rename": {
-                                        "description": "The optional output name",
-                                        "type": "string",
-                                        "nullable": true
-                                      }
-                                    },
-                                    "additionalProperties": false
-                                  },
-                                  {
-                                    "description": "Match via rgex",
-                                    "type": "object",
-                                    "required": [
-                                      "matching"
-                                    ],
-                                    "properties": {
-                                      "matching": {
-                                        "description": "Using a regex on the header name",
-                                        "type": "string"
-                                      }
-                                    },
-                                    "additionalProperties": false
-                                  }
-                                ]
-                              },
-                              "nullable": true
-                            }
-                          },
-                          "additionalProperties": false,
-                          "nullable": true
-                        },
-                        "static": {
-                          "description": "Configuration to insert custom attributes/labels in metrics",
-                          "type": "array",
-                          "items": {
-                            "description": "Configuration to insert custom attributes/labels in metrics",
-                            "type": "object",
-                            "required": [
-                              "name",
-                              "value"
-                            ],
-                            "properties": {
-                              "name": {
-                                "description": "The name of the attribute to insert",
-                                "type": "string"
-                              },
-                              "value": {
-                                "description": "The value of the attribute to insert",
-                                "anyOf": [
-                                  {
-                                    "description": "bool values",
-                                    "type": "boolean"
-                                  },
-                                  {
-                                    "description": "i64 values",
-                                    "type": "integer",
-                                    "format": "int64"
-                                  },
-                                  {
-                                    "description": "f64 values",
-                                    "type": "number",
-                                    "format": "double"
-                                  },
-                                  {
-                                    "description": "String values",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "description": "Array of homogeneous values",
-                                    "anyOf": [
-                                      {
-                                        "description": "Array of bools",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      {
-                                        "description": "Array of integers",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "integer",
-                                          "format": "int64"
-                                        }
-                                      },
-                                      {
-                                        "description": "Array of floats",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "number",
-                                          "format": "double"
-                                        }
-                                      },
-                                      {
-                                        "description": "Array of strings",
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            },
-                            "additionalProperties": false
-                          },
-                          "nullable": true
-                        }
-                      },
-                      "additionalProperties": false,
-                      "nullable": true
-                    }
-                  },
-                  "additionalProperties": false,
-                  "nullable": true
-                },
-                "buckets": {
-                  "description": "Custom buckets for histograms",
-                  "default": [
-                    0.001,
-                    0.005,
-                    0.015,
-                    0.05,
-                    0.1,
-                    0.2,
-                    0.3,
-                    0.4,
-                    0.5,
-                    1.0,
-                    5.0,
-                    10.0
-                  ],
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                },
-                "resources": {
-                  "description": "Resources",
-                  "default": {},
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                },
-                "service_name": {
-                  "description": "Set a service.name resource in your metrics",
-                  "default": null,
-                  "type": "string",
-                  "nullable": true
-                },
-                "service_namespace": {
-                  "description": "Set a service.namespace attribute in your metrics",
-                  "default": null,
-                  "type": "string",
-                  "nullable": true
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "otlp": {
-              "description": "Open Telemetry native exporter configuration",
-              "type": "object",
-              "required": [
-                "endpoint"
-              ],
-              "properties": {
-                "batch_processor": {
-                  "description": "Batch processor settings",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
-                  "type": "object",
-                  "properties": {
-                    "max_concurrent_exports": {
-                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                      "default": 1,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_batch_size": {
-                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                      "default": 512,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_timeout": {
-                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                      "default": {
-                        "secs": 30,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    },
-                    "max_queue_size": {
-                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                      "default": 2048,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "scheduled_delay": {
-                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                      "default": {
-                        "secs": 5,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    }
-                  }
-                },
-                "endpoint": {
-                  "description": "The endpoint to send data to",
-                  "type": "string"
-                },
-                "grpc": {
-                  "description": "gRPC configuration settings",
-                  "default": {
-                    "domain_name": null,
-                    "ca": null,
-                    "cert": null,
-                    "key": null,
-                    "metadata": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "ca": {
-                      "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "cert": {
-                      "description": "The optional cert for tls config",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "domain_name": {
-                      "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "key": {
-                      "description": "The optional private key file for TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "metadata": {
-                      "description": "gRPC metadata",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": true
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "http": {
-                  "description": "HTTP configuration settings",
-                  "default": {
-                    "headers": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "headers": {
-                      "description": "Headers to send on report requests",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "protocol": {
-                  "description": "The protocol to use when sending data",
-                  "default": "grpc",
-                  "type": "string",
-                  "enum": [
-                    "grpc",
-                    "http"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "prometheus": {
-              "description": "Prometheus exporter configuration",
-              "type": "object",
-              "required": [
-                "enabled"
-              ],
-              "properties": {
-                "enabled": {
-                  "description": "Set to true to enable",
-                  "type": "boolean"
-                },
-                "listen": {
-                  "description": "The listen address",
-                  "default": "127.0.0.1:9090",
-                  "anyOf": [
-                    {
-                      "description": "Socket address.",
-                      "type": "string"
-                    },
-                    {
-                      "description": "Unix socket.",
-                      "type": "string"
-                    }
-                  ]
-                },
-                "path": {
-                  "description": "The path where prometheus will be exposed",
-                  "default": "/metrics",
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "nullable": true
-        },
-        "tracing": {
-          "description": "Tracing configuration",
-          "type": "object",
-          "properties": {
-            "datadog": {
-              "description": "Datadog exporter configuration",
-              "type": "object",
-              "required": [
-                "endpoint"
-              ],
-              "properties": {
-                "batch_processor": {
-                  "description": "batch processor configuration",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
-                  "type": "object",
-                  "properties": {
-                    "max_concurrent_exports": {
-                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                      "default": 1,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_batch_size": {
-                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                      "default": 512,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_timeout": {
-                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                      "default": {
-                        "secs": 30,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    },
-                    "max_queue_size": {
-                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                      "default": 2048,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "scheduled_delay": {
-                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                      "default": {
-                        "secs": 5,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    }
-                  }
-                },
-                "enable_span_mapping": {
-                  "description": "Enable datadog span mapping for span name and resource name.",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "endpoint": {
-                  "description": "The endpoint to send to",
-                  "default": "default",
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "experimental_response_trace_id": {
-              "description": "A way to expose trace id in response headers",
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "description": "Expose the trace_id in response headers",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "header_name": {
-                  "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
-                  "type": "string",
-                  "nullable": true
-                }
-              },
-              "additionalProperties": false
-            },
-            "jaeger": {
-              "description": "Jaeger exporter configuration",
-              "anyOf": [
-                {
-                  "type": "object",
-                  "required": [
-                    "agent"
-                  ],
-                  "properties": {
-                    "agent": {
-                      "description": "Agent configuration",
-                      "type": "object",
-                      "required": [
-                        "endpoint"
-                      ],
-                      "properties": {
-                        "endpoint": {
-                          "description": "The endpoint to send to",
-                          "default": "default",
-                          "type": "string"
+                          "additionalProperties": false
                         }
                       },
                       "additionalProperties": false
                     },
-                    "batch_processor": {
-                      "description": "Batch processor configuration",
-                      "default": {
-                        "scheduled_delay": {
-                          "secs": 5,
-                          "nanos": 0
-                        },
-                        "max_queue_size": 2048,
-                        "max_export_batch_size": 512,
-                        "max_export_timeout": {
-                          "secs": 30,
-                          "nanos": 0
-                        },
-                        "max_concurrent_exports": 1
-                      },
-                      "type": "object",
-                      "properties": {
-                        "max_concurrent_exports": {
-                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                          "default": 1,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_batch_size": {
-                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                          "default": 512,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_timeout": {
-                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                          "default": {
-                            "secs": 30,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        },
-                        "max_queue_size": {
-                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                          "default": 2048,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "scheduled_delay": {
-                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                          "default": {
-                            "secs": 5,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "collector"
-                  ],
-                  "properties": {
-                    "batch_processor": {
-                      "description": "Batch processor configuration",
-                      "default": {
-                        "scheduled_delay": {
-                          "secs": 5,
-                          "nanos": 0
-                        },
-                        "max_queue_size": 2048,
-                        "max_export_batch_size": 512,
-                        "max_export_timeout": {
-                          "secs": 30,
-                          "nanos": 0
-                        },
-                        "max_concurrent_exports": 1
-                      },
-                      "type": "object",
-                      "properties": {
-                        "max_concurrent_exports": {
-                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                          "default": 1,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_batch_size": {
-                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                          "default": 512,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_timeout": {
-                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                          "default": {
-                            "secs": 30,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        },
-                        "max_queue_size": {
-                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                          "default": 2048,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "scheduled_delay": {
-                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                          "default": {
-                            "secs": 5,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "collector": {
-                      "description": "Collector configuration",
-                      "type": "object",
-                      "required": [
-                        "endpoint"
+                    "buckets": {
+                      "description": "Custom buckets for histograms",
+                      "default": [
+                        0.001,
+                        0.005,
+                        0.015,
+                        0.05,
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.4,
+                        0.5,
+                        1.0,
+                        5.0,
+                        10.0
                       ],
-                      "properties": {
-                        "endpoint": {
-                          "description": "The endpoint to send reports to",
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        "password": {
-                          "description": "The optional password",
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "username": {
-                          "description": "The optional username",
-                          "type": "string",
-                          "nullable": true
-                        }
-                      },
-                      "additionalProperties": false
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ],
-              "nullable": true
-            },
-            "otlp": {
-              "description": "OpenTelemetry native exporter configuration",
-              "type": "object",
-              "required": [
-                "endpoint"
-              ],
-              "properties": {
-                "batch_processor": {
-                  "description": "Batch processor settings",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
-                  "type": "object",
-                  "properties": {
-                    "max_concurrent_exports": {
-                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                      "default": 1,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_batch_size": {
-                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                      "default": 512,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "max_export_timeout": {
-                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                      "default": {
-                        "secs": 30,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    },
-                    "max_queue_size": {
-                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                      "default": 2048,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "scheduled_delay": {
-                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                      "default": {
-                        "secs": 5,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    }
-                  }
-                },
-                "endpoint": {
-                  "description": "The endpoint to send data to",
-                  "type": "string"
-                },
-                "grpc": {
-                  "description": "gRPC configuration settings",
-                  "default": {
-                    "domain_name": null,
-                    "ca": null,
-                    "cert": null,
-                    "key": null,
-                    "metadata": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "ca": {
-                      "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "cert": {
-                      "description": "The optional cert for tls config",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "domain_name": {
-                      "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "key": {
-                      "description": "The optional private key file for TLS configuration.",
-                      "default": null,
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "metadata": {
-                      "description": "gRPC metadata",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": true
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "http": {
-                  "description": "HTTP configuration settings",
-                  "default": {
-                    "headers": {}
-                  },
-                  "type": "object",
-                  "properties": {
-                    "headers": {
-                      "description": "Headers to send on report requests",
-                      "default": {},
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "protocol": {
-                  "description": "The protocol to use when sending data",
-                  "default": "grpc",
-                  "type": "string",
-                  "enum": [
-                    "grpc",
-                    "http"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "propagation": {
-              "description": "Propagation configuration",
-              "type": "object",
-              "properties": {
-                "baggage": {
-                  "description": "Propagate baggage https://www.w3.org/TR/baggage/",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "datadog": {
-                  "description": "Propagate Datadog",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "jaeger": {
-                  "description": "Propagate Jaeger",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "request": {
-                  "description": "Select a custom request header to set your own trace_id (header value must be convertible from hexadecimal to set a correct trace_id)",
-                  "type": "object",
-                  "required": [
-                    "header_name"
-                  ],
-                  "properties": {
-                    "header_name": {
-                      "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "trace_context": {
-                  "description": "Propagate trace context https://www.w3.org/TR/trace-context/",
-                  "default": false,
-                  "type": "boolean"
-                },
-                "zipkin": {
-                  "description": "Propagate Zipkin",
-                  "default": false,
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "trace_config": {
-              "description": "Common configuration",
-              "type": "object",
-              "properties": {
-                "attributes": {
-                  "description": "Default attributes",
-                  "default": {},
-                  "type": "object",
-                  "additionalProperties": {
-                    "anyOf": [
-                      {
-                        "description": "bool values",
-                        "type": "boolean"
-                      },
-                      {
-                        "description": "i64 values",
-                        "type": "integer",
-                        "format": "int64"
-                      },
-                      {
-                        "description": "f64 values",
+                      "type": "array",
+                      "items": {
                         "type": "number",
                         "format": "double"
+                      }
+                    },
+                    "experimental_cache_metrics": {
+                      "description": "Experimental metrics to know more about caching strategies",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "description": "Enable experimental metrics",
+                          "default": false,
+                          "type": "boolean"
+                        },
+                        "ttl": {
+                          "description": "Potential TTL for a cache if we had one (default: 5secs)",
+                          "default": "5s",
+                          "type": "string"
+                        }
                       },
-                      {
-                        "description": "String values",
-                        "type": "string"
-                      },
-                      {
-                        "description": "Array of homogeneous values",
+                      "additionalProperties": false
+                    },
+                    "resource": {
+                      "description": "The Open Telemetry resource",
+                      "default": {},
+                      "type": "object",
+                      "additionalProperties": {
                         "anyOf": [
                           {
-                            "description": "Array of bools",
-                            "type": "array",
-                            "items": {
-                              "type": "boolean"
-                            }
+                            "description": "bool values",
+                            "type": "boolean"
                           },
                           {
-                            "description": "Array of integers",
-                            "type": "array",
-                            "items": {
-                              "type": "integer",
-                              "format": "int64"
-                            }
+                            "description": "i64 values",
+                            "type": "integer",
+                            "format": "int64"
                           },
                           {
-                            "description": "Array of floats",
-                            "type": "array",
-                            "items": {
-                              "type": "number",
-                              "format": "double"
-                            }
+                            "description": "f64 values",
+                            "type": "number",
+                            "format": "double"
                           },
                           {
-                            "description": "Array of strings",
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
+                            "description": "String values",
+                            "type": "string"
+                          },
+                          {
+                            "description": "Array of homogeneous values",
+                            "anyOf": [
+                              {
+                                "description": "Array of bools",
+                                "type": "array",
+                                "items": {
+                                  "type": "boolean"
+                                }
+                              },
+                              {
+                                "description": "Array of integers",
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              },
+                              {
+                                "description": "Array of floats",
+                                "type": "array",
+                                "items": {
+                                  "type": "number",
+                                  "format": "double"
+                                }
+                              },
+                              {
+                                "description": "Array of strings",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
                           }
                         ]
                       }
-                    ]
-                  }
-                },
-                "max_attributes_per_event": {
-                  "description": "The maximum attributes per event before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_attributes_per_link": {
-                  "description": "The maximum attributes per link before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_attributes_per_span": {
-                  "description": "The maximum attributes per span before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_events_per_span": {
-                  "description": "The maximum events per span before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "max_links_per_span": {
-                  "description": "The maximum links per span before discarding",
-                  "default": 128,
-                  "type": "integer",
-                  "format": "uint32",
-                  "minimum": 0.0
-                },
-                "parent_based_sampler": {
-                  "description": "Whether to use parent based sampling",
-                  "default": true,
-                  "type": "boolean"
-                },
-                "sampler": {
-                  "description": "The sampler, always_on, always_off or a decimal between 0.0 and 1.0",
-                  "anyOf": [
-                    {
-                      "description": "Sample a given fraction. Fractions >= 1 will always sample.",
-                      "type": "number",
-                      "format": "double"
                     },
-                    {
+                    "service_name": {
+                      "description": "Set a service.name resource in your metrics",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "service_namespace": {
+                      "description": "Set a service.namespace attribute in your metrics",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "otlp": {
+                  "description": "Open Telemetry native exporter configuration",
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "batch_processor": {
+                      "description": "Batch processor settings",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable otlp",
+                      "type": "boolean"
+                    },
+                    "endpoint": {
+                      "description": "The endpoint to send data to",
+                      "type": "string"
+                    },
+                    "grpc": {
+                      "description": "gRPC configuration settings",
+                      "default": {
+                        "domain_name": null,
+                        "ca": null,
+                        "cert": null,
+                        "key": null,
+                        "metadata": {}
+                      },
+                      "type": "object",
+                      "properties": {
+                        "ca": {
+                          "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "cert": {
+                          "description": "The optional cert for tls config",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "domain_name": {
+                          "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "key": {
+                          "description": "The optional private key file for TLS configuration.",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "metadata": {
+                          "description": "gRPC metadata",
+                          "default": {},
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "http": {
+                      "description": "HTTP configuration settings",
+                      "default": {
+                        "headers": {}
+                      },
+                      "type": "object",
+                      "properties": {
+                        "headers": {
+                          "description": "Headers to send on report requests",
+                          "default": {},
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "protocol": {
+                      "description": "The protocol to use when sending data",
+                      "default": "grpc",
+                      "type": "string",
+                      "enum": [
+                        "grpc",
+                        "http"
+                      ]
+                    },
+                    "temporality": {
+                      "description": "Temporality for export (default: `Cumulative`). Note that when exporting to Datadog agent use `Delta`.",
+                      "default": "cumulative",
                       "oneOf": [
                         {
-                          "description": "Always sample",
+                          "description": "Export cumulative metrics.",
                           "type": "string",
                           "enum": [
-                            "always_on"
+                            "cumulative"
                           ]
                         },
                         {
-                          "description": "Never sample",
+                          "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
                           "type": "string",
                           "enum": [
-                            "always_off"
+                            "delta"
                           ]
                         }
                       ]
                     }
-                  ]
-                },
-                "service_name": {
-                  "description": "The trace service name",
-                  "default": "router",
-                  "type": "string"
-                },
-                "service_namespace": {
-                  "description": "The trace service namespace",
-                  "default": "",
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "nullable": true
-            },
-            "zipkin": {
-              "description": "Zipkin exporter configuration",
-              "type": "object",
-              "properties": {
-                "batch_processor": {
-                  "description": "Batch processor configuration",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
                   },
+                  "additionalProperties": false
+                },
+                "prometheus": {
+                  "description": "Prometheus exporter configuration",
                   "type": "object",
                   "properties": {
-                    "max_concurrent_exports": {
-                      "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                      "default": 1,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
+                    "enabled": {
+                      "description": "Set to true to enable",
+                      "default": false,
+                      "type": "boolean"
                     },
-                    "max_export_batch_size": {
-                      "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                      "default": 512,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
+                    "listen": {
+                      "description": "The listen address",
+                      "default": "127.0.0.1:9090",
+                      "anyOf": [
+                        {
+                          "description": "Socket address.",
+                          "type": "string"
+                        },
+                        {
+                          "description": "Unix socket.",
+                          "type": "string"
+                        }
+                      ]
                     },
-                    "max_export_timeout": {
-                      "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                      "default": {
-                        "secs": 30,
-                        "nanos": 0
-                      },
-                      "type": "string"
-                    },
-                    "max_queue_size": {
-                      "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                      "default": 2048,
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    "scheduled_delay": {
-                      "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                      "default": {
-                        "secs": 5,
-                        "nanos": 0
-                      },
+                    "path": {
+                      "description": "The path where prometheus will be exposed",
+                      "default": "/metrics",
                       "type": "string"
                     }
-                  }
-                },
-                "endpoint": {
-                  "description": "The endpoint to send to",
-                  "default": "default",
-                  "type": "string"
+                  },
+                  "additionalProperties": false
                 }
               },
-              "additionalProperties": false,
-              "nullable": true
+              "additionalProperties": false
+            },
+            "tracing": {
+              "description": "Tracing configuration",
+              "type": "object",
+              "properties": {
+                "common": {
+                  "description": "Common configuration",
+                  "type": "object",
+                  "properties": {
+                    "max_attributes_per_event": {
+                      "description": "The maximum attributes per event before discarding",
+                      "default": 128,
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "max_attributes_per_link": {
+                      "description": "The maximum attributes per link before discarding",
+                      "default": 128,
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "max_attributes_per_span": {
+                      "description": "The maximum attributes per span before discarding",
+                      "default": 128,
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "max_events_per_span": {
+                      "description": "The maximum events per span before discarding",
+                      "default": 128,
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "max_links_per_span": {
+                      "description": "The maximum links per span before discarding",
+                      "default": 128,
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "parent_based_sampler": {
+                      "description": "Whether to use parent based sampling",
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "resource": {
+                      "description": "The Open Telemetry resource",
+                      "default": {},
+                      "type": "object",
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "description": "bool values",
+                            "type": "boolean"
+                          },
+                          {
+                            "description": "i64 values",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          {
+                            "description": "f64 values",
+                            "type": "number",
+                            "format": "double"
+                          },
+                          {
+                            "description": "String values",
+                            "type": "string"
+                          },
+                          {
+                            "description": "Array of homogeneous values",
+                            "anyOf": [
+                              {
+                                "description": "Array of bools",
+                                "type": "array",
+                                "items": {
+                                  "type": "boolean"
+                                }
+                              },
+                              {
+                                "description": "Array of integers",
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              },
+                              {
+                                "description": "Array of floats",
+                                "type": "array",
+                                "items": {
+                                  "type": "number",
+                                  "format": "double"
+                                }
+                              },
+                              {
+                                "description": "Array of strings",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "sampler": {
+                      "description": "The sampler, always_on, always_off or a decimal between 0.0 and 1.0",
+                      "anyOf": [
+                        {
+                          "description": "Sample a given fraction. Fractions >= 1 will always sample.",
+                          "type": "number",
+                          "format": "double"
+                        },
+                        {
+                          "oneOf": [
+                            {
+                              "description": "Always sample",
+                              "type": "string",
+                              "enum": [
+                                "always_on"
+                              ]
+                            },
+                            {
+                              "description": "Never sample",
+                              "type": "string",
+                              "enum": [
+                                "always_off"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "service_name": {
+                      "description": "The trace service name",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "service_namespace": {
+                      "description": "The trace service namespace",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "datadog": {
+                  "description": "Datadog exporter configuration",
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "batch_processor": {
+                      "description": "batch processor configuration",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "enable_span_mapping": {
+                      "description": "Enable datadog span mapping for span name and resource name.",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "description": "Enable datadog",
+                      "type": "boolean"
+                    },
+                    "endpoint": {
+                      "description": "The endpoint to send to",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "experimental_response_trace_id": {
+                  "description": "A way to expose trace id in response headers",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Expose the trace_id in response headers",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "header_name": {
+                      "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "jaeger": {
+                  "description": "Jaeger exporter configuration",
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "enabled"
+                      ],
+                      "properties": {
+                        "agent": {
+                          "description": "Agent configuration",
+                          "type": "object",
+                          "properties": {
+                            "endpoint": {
+                              "description": "The endpoint to send to",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "batch_processor": {
+                          "description": "Batch processor configuration",
+                          "type": "object",
+                          "properties": {
+                            "max_concurrent_exports": {
+                              "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                              "default": 1,
+                              "type": "integer",
+                              "format": "uint",
+                              "minimum": 0.0
+                            },
+                            "max_export_batch_size": {
+                              "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                              "default": 512,
+                              "type": "integer",
+                              "format": "uint",
+                              "minimum": 0.0
+                            },
+                            "max_export_timeout": {
+                              "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                              "default": {
+                                "secs": 30,
+                                "nanos": 0
+                              },
+                              "type": "string"
+                            },
+                            "max_queue_size": {
+                              "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                              "default": 2048,
+                              "type": "integer",
+                              "format": "uint",
+                              "minimum": 0.0
+                            },
+                            "scheduled_delay": {
+                              "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                              "default": {
+                                "secs": 5,
+                                "nanos": 0
+                              },
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "enabled": {
+                          "description": "Enable Jaeger",
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "enabled"
+                      ],
+                      "properties": {
+                        "batch_processor": {
+                          "description": "Batch processor configuration",
+                          "type": "object",
+                          "properties": {
+                            "max_concurrent_exports": {
+                              "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                              "default": 1,
+                              "type": "integer",
+                              "format": "uint",
+                              "minimum": 0.0
+                            },
+                            "max_export_batch_size": {
+                              "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                              "default": 512,
+                              "type": "integer",
+                              "format": "uint",
+                              "minimum": 0.0
+                            },
+                            "max_export_timeout": {
+                              "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                              "default": {
+                                "secs": 30,
+                                "nanos": 0
+                              },
+                              "type": "string"
+                            },
+                            "max_queue_size": {
+                              "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                              "default": 2048,
+                              "type": "integer",
+                              "format": "uint",
+                              "minimum": 0.0
+                            },
+                            "scheduled_delay": {
+                              "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                              "default": {
+                                "secs": 5,
+                                "nanos": 0
+                              },
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "collector": {
+                          "description": "Collector configuration",
+                          "type": "object",
+                          "properties": {
+                            "endpoint": {
+                              "description": "The endpoint to send reports to",
+                              "type": "string"
+                            },
+                            "password": {
+                              "description": "The optional password",
+                              "default": null,
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "username": {
+                              "description": "The optional username",
+                              "default": null,
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "enabled": {
+                          "description": "Enable Jaeger",
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "otlp": {
+                  "description": "OpenTelemetry native exporter configuration",
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "batch_processor": {
+                      "description": "Batch processor settings",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable otlp",
+                      "type": "boolean"
+                    },
+                    "endpoint": {
+                      "description": "The endpoint to send data to",
+                      "type": "string"
+                    },
+                    "grpc": {
+                      "description": "gRPC configuration settings",
+                      "default": {
+                        "domain_name": null,
+                        "ca": null,
+                        "cert": null,
+                        "key": null,
+                        "metadata": {}
+                      },
+                      "type": "object",
+                      "properties": {
+                        "ca": {
+                          "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "cert": {
+                          "description": "The optional cert for tls config",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "domain_name": {
+                          "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "key": {
+                          "description": "The optional private key file for TLS configuration.",
+                          "default": null,
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "metadata": {
+                          "description": "gRPC metadata",
+                          "default": {},
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "http": {
+                      "description": "HTTP configuration settings",
+                      "default": {
+                        "headers": {}
+                      },
+                      "type": "object",
+                      "properties": {
+                        "headers": {
+                          "description": "Headers to send on report requests",
+                          "default": {},
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "protocol": {
+                      "description": "The protocol to use when sending data",
+                      "default": "grpc",
+                      "type": "string",
+                      "enum": [
+                        "grpc",
+                        "http"
+                      ]
+                    },
+                    "temporality": {
+                      "description": "Temporality for export (default: `Cumulative`). Note that when exporting to Datadog agent use `Delta`.",
+                      "default": "cumulative",
+                      "oneOf": [
+                        {
+                          "description": "Export cumulative metrics.",
+                          "type": "string",
+                          "enum": [
+                            "cumulative"
+                          ]
+                        },
+                        {
+                          "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
+                          "type": "string",
+                          "enum": [
+                            "delta"
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "propagation": {
+                  "description": "Propagation configuration",
+                  "type": "object",
+                  "properties": {
+                    "aws_xray": {
+                      "description": "Propagate AWS X-Ray",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "baggage": {
+                      "description": "Propagate baggage https://www.w3.org/TR/baggage/",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "datadog": {
+                      "description": "Propagate Datadog",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "jaeger": {
+                      "description": "Propagate Jaeger",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "request": {
+                      "description": "Select a custom request header to set your own trace_id (header value must be convertible from hexadecimal to set a correct trace_id)",
+                      "type": "object",
+                      "required": [
+                        "header_name"
+                      ],
+                      "properties": {
+                        "header_name": {
+                          "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "trace_context": {
+                      "description": "Propagate trace context https://www.w3.org/TR/trace-context/",
+                      "default": false,
+                      "type": "boolean"
+                    },
+                    "zipkin": {
+                      "description": "Propagate Zipkin",
+                      "default": false,
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "zipkin": {
+                  "description": "Zipkin exporter configuration",
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "batch_processor": {
+                      "description": "Batch processor configuration",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable zipkin",
+                      "type": "boolean"
+                    },
+                    "endpoint": {
+                      "description": "The endpoint to send to",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           },
-          "additionalProperties": false,
-          "nullable": true
+          "additionalProperties": false
+        },
+        "instrumentation": {
+          "description": "Instrumentation configuration",
+          "type": "object",
+          "properties": {
+            "spans": {
+              "description": "Span configuration",
+              "type": "object",
+              "properties": {
+                "default_attribute_requirement_level": {
+                  "description": "The attributes to include by default in spans based on their level as specified in the otel semantic conventions and Apollo documentation.",
+                  "oneOf": [
+                    {
+                      "description": "No default attributes set on spans, you have to set it one by one in the configuration to enable some attributes",
+                      "type": "string",
+                      "enum": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "description": "Attributes that are marked as required in otel semantic conventions and apollo documentation will be included (default)",
+                      "type": "string",
+                      "enum": [
+                        "required"
+                      ]
+                    },
+                    {
+                      "description": "Attributes that are marked as required or recommended in otel semantic conventions and apollo documentation will be included",
+                      "type": "string",
+                      "enum": [
+                        "recommended"
+                      ]
+                    }
+                  ]
+                },
+                "mode": {
+                  "description": "Use new OpenTelemetry spec compliant span attributes or preserve existing. This will be defaulted in future to `spec_compliant`, eventually removed in future.",
+                  "oneOf": [
+                    {
+                      "description": "Keep the request span as root span and deprecated attributes. This option will eventually removed.",
+                      "type": "string",
+                      "enum": [
+                        "deprecated"
+                      ]
+                    },
+                    {
+                      "description": "Use new OpenTelemetry spec compliant span attributes or preserve existing. This will be the default in future.",
+                      "type": "string",
+                      "enum": [
+                        "spec_compliant"
+                      ]
+                    }
+                  ]
+                },
+                "router": {
+                  "description": "Configuration of router spans. Log events inherit attributes from the containing span, so attributes configured here will be included on log events for a request. Router spans contain http request and response information and therefore contain http specific attributes.",
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "description": "Custom attributes that are attached to the router span.",
+                      "type": "object",
+                      "properties": {
+                        "dd.trace_id": {
+                          "description": "The datadog trace ID. This can be output in logs and used to correlate traces in Datadog.",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "error.type": {
+                          "description": "Describes a class of error the operation ended with. Examples: * timeout * name_resolution_error * 500 Requirement level: Conditionally Required: If request has ended with an error.",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "http.request.body.size": {
+                          "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "http.request.method": {
+                          "description": "HTTP request method. Examples: * GET * POST * HEAD Requirement level: Required",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "http.response.body.size": {
+                          "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "http.response.status_code": {
+                          "description": "HTTP response status code. Examples: * 200 Requirement level: Conditionally Required: If and only if one was received/sent.",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "http.route": {
+                          "description": "The matched route (path template in the format used by the respective server framework). Examples: * /graphql Requirement level: Conditionally Required: If and only if it’s available",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.local.address": {
+                          "description": "Local socket address. Useful in case of a multi-IP host. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Opt-In",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.local.port": {
+                          "description": "Local socket port. Useful in case of a multi-port host. Examples: * 65123 Requirement level: Opt-In",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.peer.address": {
+                          "description": "Peer address of the network connection - IP address or Unix domain socket name. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.peer.port": {
+                          "description": "Peer port number of the network connection. Examples: * 65123 Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.protocol.name": {
+                          "description": "OSI application layer or non-OSI equivalent. Examples: * http * spdy Requirement level: Recommended: if not default (http).",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.protocol.version": {
+                          "description": "Version of the protocol specified in network.protocol.name. Examples: * 1.0 * 1.1 * 2 * 3 Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.transport": {
+                          "description": "OSI transport layer. Examples: * tcp * udp Requirement level: Conditionally Required",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "network.type": {
+                          "description": "OSI network layer or non-OSI equivalent. Examples: * ipv4 * ipv6 Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "server.address": {
+                          "description": "Name of the local HTTP server that received the request. Examples: * example.com * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "server.port": {
+                          "description": "Port of the local HTTP server that received the request. Examples: * 80 * 8080 * 443 Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "trace_id": {
+                          "description": "The OpenTelemetry trace ID. This can be output in logs.",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "url.path": {
+                          "description": "The URI path component Examples: * /search Requirement level: Required",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "url.query": {
+                          "description": "The URI query component Examples: * q=OpenTelemetry Requirement level: Conditionally Required: If and only if one was received/sent.",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "url.scheme": {
+                          "description": "The URI scheme component identifying the used protocol. Examples: * http * https Requirement level: Required",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "user_agent.original": {
+                          "description": "Value of the HTTP User-Agent header sent by the client. Examples: * CERN-LineMode/2.15 * libwww/2.17b3 Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        }
+                      },
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "description": "A header from the request",
+                            "type": "object",
+                            "required": [
+                              "request_header"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "request_header": {
+                                "description": "The name of the request header.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "A header from the response",
+                            "type": "object",
+                            "required": [
+                              "response_header"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "response_header": {
+                                "description": "The name of the request header.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "A header from the response",
+                            "type": "object",
+                            "required": [
+                              "response_status"
+                            ],
+                            "properties": {
+                              "response_status": {
+                                "description": "The http response status code.",
+                                "oneOf": [
+                                  {
+                                    "description": "The http status code.",
+                                    "type": "string",
+                                    "enum": [
+                                      "code"
+                                    ]
+                                  },
+                                  {
+                                    "description": "The http status reason.",
+                                    "type": "string",
+                                    "enum": [
+                                      "reason"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "The trace ID of the request.",
+                            "type": "object",
+                            "required": [
+                              "trace_id"
+                            ],
+                            "properties": {
+                              "trace_id": {
+                                "description": "The format of the trace ID.",
+                                "oneOf": [
+                                  {
+                                    "description": "Open Telemetry trace ID, a hex string.",
+                                    "type": "string",
+                                    "enum": [
+                                      "open_telemetry"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Datadog trace ID, a u64.",
+                                    "type": "string",
+                                    "enum": [
+                                      "datadog"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "A value from context.",
+                            "type": "object",
+                            "required": [
+                              "response_context"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "response_context": {
+                                "description": "The response context key.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "A value from baggage.",
+                            "type": "object",
+                            "required": [
+                              "baggage"
+                            ],
+                            "properties": {
+                              "baggage": {
+                                "description": "The name of the baggage item.",
+                                "type": "string"
+                              },
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "A value from an environment variable.",
+                            "type": "object",
+                            "required": [
+                              "env"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "env": {
+                                "description": "The name of the environment variable",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "subgraph": {
+                  "description": "Attributes to include on the subgraph span. Subgraph spans contain information about the subgraph request and response and therefore contain subgraph specific attributes.",
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "description": "Custom attributes that are attached to the subgraph span.",
+                      "type": "object",
+                      "properties": {
+                        "subgraph.graphql.document": {
+                          "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "subgraph.graphql.operation.name": {
+                          "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "subgraph.graphql.operation.type": {
+                          "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "subgraph.name": {
+                          "description": "The name of the subgraph Examples: * products Requirement level: Required",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        }
+                      },
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_operation_name"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "subgraph_operation_name": {
+                                "description": "The operation name from the subgraph query.",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw operation name.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "description": "A hash of the operation name.",
+                                    "type": "string",
+                                    "enum": [
+                                      "hash"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_operation_kind"
+                            ],
+                            "properties": {
+                              "subgraph_operation_kind": {
+                                "description": "The kind of the subgraph operation (query|mutation|subscription).",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw operation kind.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_query"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "subgraph_query": {
+                                "description": "The graphql query to the subgraph.",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw query kind.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_query_variable"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "subgraph_query_variable": {
+                                "description": "The name of a subgraph query variable.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_response_body"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "subgraph_response_body": {
+                                "description": "The subgraph response body json path.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_request_header"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "subgraph_request_header": {
+                                "description": "The name of a subgraph request header.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_response_header"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "subgraph_response_header": {
+                                "description": "The name of a subgraph response header.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_response_status"
+                            ],
+                            "properties": {
+                              "subgraph_response_status": {
+                                "description": "The subgraph http response status code.",
+                                "oneOf": [
+                                  {
+                                    "description": "The http status code.",
+                                    "type": "string",
+                                    "enum": [
+                                      "code"
+                                    ]
+                                  },
+                                  {
+                                    "description": "The http status reason.",
+                                    "type": "string",
+                                    "enum": [
+                                      "reason"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "supergraph_operation_name"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "supergraph_operation_name": {
+                                "description": "The supergraph query operation name.",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw operation name.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "description": "A hash of the operation name.",
+                                    "type": "string",
+                                    "enum": [
+                                      "hash"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "supergraph_operation_kind"
+                            ],
+                            "properties": {
+                              "supergraph_operation_kind": {
+                                "description": "The supergraph query operation kind (query|mutation|subscription).",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw operation kind.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "supergraph_query"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "supergraph_query": {
+                                "description": "The supergraph query to the subgraph.",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw query kind.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "supergraph_query_variable"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "supergraph_query_variable": {
+                                "description": "The supergraph query variable name.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "supergraph_request_header"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "supergraph_request_header": {
+                                "description": "The supergraph request header name.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "request_context"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "request_context": {
+                                "description": "The request context key.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "response_context"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "response_context": {
+                                "description": "The response context key.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "baggage"
+                            ],
+                            "properties": {
+                              "baggage": {
+                                "description": "The name of the baggage item.",
+                                "type": "string"
+                              },
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "env"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "env": {
+                                "description": "The name of the environment variable",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "supergraph": {
+                  "description": "Configuration of supergraph spans. Supergraph spans contain information about the graphql request and response and therefore contain graphql specific attributes.",
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "description": "Custom attributes that are attached to the supergraph span.",
+                      "type": "object",
+                      "properties": {
+                        "graphql.document": {
+                          "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "graphql.operation.name": {
+                          "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        },
+                        "graphql.operation.type": {
+                          "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
+                          "default": null,
+                          "type": "boolean",
+                          "nullable": true
+                        }
+                      },
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "operation_name"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "operation_name": {
+                                "description": "The operation name from the query.",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw operation name.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  },
+                                  {
+                                    "description": "A hash of the operation name.",
+                                    "type": "string",
+                                    "enum": [
+                                      "hash"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "operation_kind"
+                            ],
+                            "properties": {
+                              "operation_kind": {
+                                "description": "The operation kind from the query (query|mutation|subscription).",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw operation kind.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "query"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "query": {
+                                "description": "The graphql query.",
+                                "oneOf": [
+                                  {
+                                    "description": "The raw query kind.",
+                                    "type": "string",
+                                    "enum": [
+                                      "string"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "query_variable"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "query_variable": {
+                                "description": "The name of a graphql query variable.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "request_header"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "request_header": {
+                                "description": "The name of the request header.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "response_header"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "response_header": {
+                                "description": "The name of the response header.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "request_context"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "request_context": {
+                                "description": "The request context key.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "response_context"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "response_context": {
+                                "description": "The response context key.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "baggage"
+                            ],
+                            "properties": {
+                              "baggage": {
+                                "description": "The name of the baggage item.",
+                                "type": "string"
+                              },
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "env"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "env": {
+                                "description": "The name of the environment variable",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -4626,7 +7438,8 @@
         "supergraph": null,
         "subgraph": {
           "all": {
-            "certificate_authorities": null
+            "certificate_authorities": null,
+            "client_authentication": null
           },
           "subgraphs": {}
         }
@@ -4637,7 +7450,8 @@
           "description": "Configuration options pertaining to the subgraph server component.",
           "default": {
             "all": {
-              "certificate_authorities": null
+              "certificate_authorities": null,
+              "client_authentication": null
             },
             "subgraphs": {}
           },
@@ -4646,7 +7460,8 @@
             "all": {
               "description": "options applying to all subgraphs",
               "default": {
-                "certificate_authorities": null
+                "certificate_authorities": null,
+                "client_authentication": null
               },
               "type": "object",
               "properties": {
@@ -4654,6 +7469,29 @@
                   "description": "list of certificate authorities in PEM format",
                   "default": null,
                   "type": "string",
+                  "nullable": true
+                },
+                "client_authentication": {
+                  "description": "client certificate authentication",
+                  "default": null,
+                  "type": "object",
+                  "required": [
+                    "certificate_chain",
+                    "key"
+                  ],
+                  "properties": {
+                    "certificate_chain": {
+                      "description": "list of certificates in PEM format",
+                      "writeOnly": true,
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "key in PEM format",
+                      "writeOnly": true,
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
                   "nullable": true
                 }
               },
@@ -4671,6 +7509,29 @@
                     "description": "list of certificate authorities in PEM format",
                     "default": null,
                     "type": "string",
+                    "nullable": true
+                  },
+                  "client_authentication": {
+                    "description": "client certificate authentication",
+                    "default": null,
+                    "type": "object",
+                    "required": [
+                      "certificate_chain",
+                      "key"
+                    ],
+                    "properties": {
+                      "certificate_chain": {
+                        "description": "list of certificates in PEM format",
+                        "writeOnly": true,
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "key in PEM format",
+                        "writeOnly": true,
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false,
                     "nullable": true
                   }
                 },
@@ -4751,11 +7612,6 @@
               "type": "boolean",
               "nullable": true
             },
-            "experimental_enable_http2": {
-              "description": "Enable HTTP2 for subgraphs",
-              "type": "boolean",
-              "nullable": true
-            },
             "experimental_entity_caching": {
               "description": "Enable entity caching",
               "type": "object",
@@ -4769,6 +7625,33 @@
                 }
               },
               "additionalProperties": false,
+              "nullable": true
+            },
+            "experimental_http2": {
+              "description": "Enable HTTP2 for subgraphs",
+              "oneOf": [
+                {
+                  "description": "Enable HTTP2 for subgraphs",
+                  "type": "string",
+                  "enum": [
+                    "enable"
+                  ]
+                },
+                {
+                  "description": "Disable HTTP2 for subgraphs",
+                  "type": "string",
+                  "enum": [
+                    "disable"
+                  ]
+                },
+                {
+                  "description": "Only HTTP2 is active",
+                  "type": "string",
+                  "enum": [
+                    "http2only"
+                  ]
+                }
+              ],
               "nullable": true
             },
             "experimental_retry": {
@@ -4847,6 +7730,18 @@
             "urls"
           ],
           "properties": {
+            "timeout": {
+              "description": "Redis request timeout (default: 2ms)",
+              "default": null,
+              "type": "string",
+              "nullable": true
+            },
+            "ttl": {
+              "description": "TTL for entries",
+              "default": null,
+              "type": "string",
+              "nullable": true
+            },
             "urls": {
               "description": "List of URLs to the Redis cluster",
               "type": "array",
@@ -4933,11 +7828,6 @@
                 "type": "boolean",
                 "nullable": true
               },
-              "experimental_enable_http2": {
-                "description": "Enable HTTP2 for subgraphs",
-                "type": "boolean",
-                "nullable": true
-              },
               "experimental_entity_caching": {
                 "description": "Enable entity caching",
                 "type": "object",
@@ -4951,6 +7841,33 @@
                   }
                 },
                 "additionalProperties": false,
+                "nullable": true
+              },
+              "experimental_http2": {
+                "description": "Enable HTTP2 for subgraphs",
+                "oneOf": [
+                  {
+                    "description": "Enable HTTP2 for subgraphs",
+                    "type": "string",
+                    "enum": [
+                      "enable"
+                    ]
+                  },
+                  {
+                    "description": "Disable HTTP2 for subgraphs",
+                    "type": "string",
+                    "enum": [
+                      "disable"
+                    ]
+                  },
+                  {
+                    "description": "Only HTTP2 is active",
+                    "type": "string",
+                    "enum": [
+                      "http2only"
+                    ]
+                  }
+                ],
                 "nullable": true
               },
               "experimental_retry": {

--- a/router/router_baseline.yaml
+++ b/router/router_baseline.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../router.config.json
 supergraph:
   listen: 0.0.0.0:4040
   path: /


### PR DESCRIPTION
Bumps the router to 1.35 as well as fixing the Go impl to return the proper `break` casing for the response. 